### PR TITLE
fix: pass src to render the file

### DIFF
--- a/ssr/render.js
+++ b/ssr/render.js
@@ -293,7 +293,7 @@ export async function parseFile(path) {
 
 export async function renderFile(path, data, deps) {
   const src = await fs.readFile(path, 'utf-8')
-  return render(path, data, deps)
+  return render(src, data, deps)
 }
 
 


### PR DESCRIPTION
I was trying to render a file using `renderFile` and realized it wasn't passing `src` to render.