### PR TITLE
fix: jsdoc optional param

### DIFF
--- a/src/nue.js
+++ b/src/nue.js
@@ -13,8 +13,8 @@ const CORE_ATTR = ['class', 'style', 'id']
  *
  * @typedef {{ name: string, tagName: string, tmpl: string, ... }} Component
  * @param { Component } component - a (compiled) component instance to be mounted
- * @param { Object } [data] - optional data or data model for the component
- * @param { Array<Component> } [deps] - optional array of nested/dependant components
+ * @param { Object } [data = {}] - optional data or data model for the component
+ * @param { Array<Component> } [deps = {}] - optional array of nested/dependant components
  * @param { Object } $parent - (for internal use only)
 */
 export default function createApp(component, data={}, deps=[], $parent={}) {

--- a/src/nue.js
+++ b/src/nue.js
@@ -13,8 +13,8 @@ const CORE_ATTR = ['class', 'style', 'id']
  *
  * @typedef {{ name: string, tagName: string, tmpl: string, ... }} Component
  * @param { Component } component - a (compiled) component instance to be mounted
- * @param { Object } data? - optional data or data model for the component
- * @param { Array<Component> } deps - optional array of nested/dependant components
+ * @param { Object } [data] - optional data or data model for the component
+ * @param { Array<Component> } [deps] - optional array of nested/dependant components
  * @param { Object } $parent - (for internal use only)
 */
 export default function createApp(component, data={}, deps=[], $parent={}) {


### PR DESCRIPTION
You can get usage from  [tags-param](https://jsdoc.app/tags-param.html) or [jsdoc-supported-types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#param-and-returns)
> // Parameters may be declared in a variety of syntactic forms
>/**
> * @param {string}  p1 - A string param.
> * @param {string=} p2 - An optional param (Google Closure syntax)
> * @param {string} [p3] - Another optional param (JSDoc syntax).
> * @param {string} [p4="test"] - An optional param with a default value
> * @returns {string} This is the result
> */
>function stringsStringStrings(p1, p2, p3, p4) {
>  // TODO
>}