### PR TITLE
Add SVG elements to standard element list, fix #60

### DIFF
--- a/ssr/fn.js
+++ b/ssr/fn.js
@@ -4,13 +4,14 @@ import { parseDocument, DomUtils } from 'htmlparser2'
 // shared by render.js and compile.js
 
 export const STD = 'a abbr acronym address applet area article aside audio b base basefont bdi bdo big\
- blockquote body br button canvas caption center cite code col colgroup data datalist dd del\
- details dfn dialog dir div dl dt em embed fieldset figcaption figure font footer form frame\
- frameset head header hgroup h1 h2 h3 h4 h5 h6 hr html i iframe img input ins kbd keygen label\
- legend li link main map mark menu menuitem meta meter nav noframes noscript object ol optgroup\
- option output p param picture pre progress q rp rt ruby s samp script section select small\
- source span strike strong style sub summary sup svg table tbody td template textarea tfoot th\
- thead time title tr track tt u ul var video wbr'.split(' ')
+ blockquote body br button canvas caption center circle cite clipPath code col colgroup data datalist\
+ dd defs del details dfn dialog dir div dl dt ellipse em embed fieldset figcaption figure font footer\
+ foreignObject form frame frameset g head header hgroup h1 h2 h3 h4 h5 h6 hr html i iframe image img\
+ input ins kbd keygen label legend li line link main map mark marker mask menu menuitem meta meter\
+ nav noframes noscript object ol optgroup option output p param path pattern picture polygon polyline\
+ pre progress q rect rp rt ruby s samp script section select small source span strike strong style sub\
+ summary sup svg switch symbol table tbody td template text textarea textPath tfoot th thead time\
+ title tr track tspan tt u ul use var video wbr'.split(' ')
 
 const BOOLEAN = `allowfullscreen async autofocus autoplay checked controls default
   defer disabled formnovalidate hidden ismap itemscope loop multiple muted nomodule novalidate


### PR DESCRIPTION
Inline svg elements in .nue files get replaced with `<nue-island>`

``` html
<svg style="display:none;>
  <symbol id="collapse" viewBox="0 0 16 16">
    <polygon points="11.62 3.81 7.43 8 11.62 12.19 10.09 13.71 4.38 8 10.09 2.29 11.62 3.81" />
  </symbol>
</svg>
```

in a .nue file is compiled to

``` html
<svg style="display:none;>
  <nue-island id="collapse" viewBox="0 0 16 16">
    <nue-island points="11.62 3.81 7.43 8 11.62 12.19 10.09 13.71 4.38 8 10.09 2.29 11.62 3.81" />
  </nue-island>
</svg>
```

We should add the svg elements to the standard element list.
[SVG container elements](https://svgwg.org/svg2-draft/struct.html#TermContainerElement)
[SVG graphics elements](https://svgwg.org/svg2-draft/struct.html#TermGraphicsElement) 