### PR TITLE
Add: Prettier configuration

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,8 +1,0 @@
-/** @type {import("prettier").Config} */
-const config = {
-  tabWidth: 2,
-  semi: false,
-  singleQuote: true,
-}
-
-module.exports = config

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,16 @@
+printWidth: 100
+tabWidth: 2
+useTabs: false
+semi: false
+singleQuote: true
+quoteProps: 'as-needed'
+trailingComma: 'es5'
+bracketSpacing: true
+arrowParens: 'avoid'
+requirePragma: false
+insertPragma: false
+proseWrap: 'preserve'
+htmlWhitespaceSensitivity: 'css'
+endOfLine: 'lf'
+embeddedLanguageFormatting: 'auto'
+singleAttributePerLine: false


### PR DESCRIPTION
Mapped all Prettier options to match the project's style, as discussed in PR #54.
Converted the configuration to YAML, for its simplicity.