### PR TITLE
Fix Typo VARIABLE regular expression

### DIFF
--- a/ssr/expr.js
+++ b/ssr/expr.js
@@ -1,5 +1,5 @@
 
-const VARIABLE = /(^|[\-\+\*\/\!\s\(\[]+)([\$,a-z,_]\w*)\b/g
+const VARIABLE = /(^|[\-\+\*\/\!\s\(\[]+)([\$a-z_]\w*)\b/g
 const STRING = /('[^']+'|"[^"]+")/
 const EXPR = /\{([^}]+)\}/g
 


### PR DESCRIPTION
Seems like typo in VARIABLE regular expression.

```javascript
[\$,a-z,_]
```

This codes allow `,` to be matched, and even if you want to include `,` you don't have to include `,` twice.

<img width="379" alt="スクリーンショット 2023-10-01 15 00 41" src="https://github.com/nuejs/nuejs/assets/8908109/4775f9b4-9316-4ccb-8f72-995e812e6022">

----

For other codes, [here use 'map' for loop](https://github.com/nuejs/nuejs/blob/7945d8b5fd0b5850a0e56c1e70e8bc0cb2b79b5b/ssr/expr.js#L34) but you can use `forEach` instead, since forEach don't generate new array and therefore more cost effectively.