### PR TITLE
Fix rendering the nodes after HTML comment

### DIFF
--- a/ssr/fn.js
+++ b/ssr/fn.js
@@ -39,8 +39,9 @@ export function selfClose(str) {
 export function walk(node, fn) {
   fn(node)
   node = node.firstChild
+  let next = null
   while (node) {
-    const next = node.nextSibling
+    next = node.nextSibling
     walk(node, fn)
     node = next
   }

--- a/ssr/fn.js
+++ b/ssr/fn.js
@@ -40,8 +40,9 @@ export function walk(node, fn) {
   fn(node)
   node = node.firstChild
   while (node) {
+    const next = node.nextSibling
     walk(node, fn)
-    node = node.nextSibling
+    node = next
   }
 }
 


### PR DESCRIPTION
When we remove a node, specifically a comment node, we also remove the `nextSibling` property. This absence of the `nextSibling` property causes the walk function to terminate, subsequently resulting in falsy rendering. [source](https://github.com/nuejs/nuejs/blob/master/ssr/compile.js#L23)

[Example](https://github.com/hichem-dahi/create-nue/blob/master/src/islands.nue):
The produced islands.js Before
```
{...
  fns: [
    _ => _.contactInput.firstname,
    (_,e) => { _.contactInput.firstname = e.target.value },
    _ => _.contactInput.lastname,
    (_,e) => { _.contactInput.lastname = e.target.value },
    _ => _.contactInput.gender,
    (_,e) => { _.contactInput.gender = e.target.value }
  ]
},
```
The produced islands.js. After adding the `next` variable in the walk function 
 ```
{...
 fns: [
    _ => _.contactInput.firstname,
    (_,e) => { _.contactInput.firstname = e.target.value },
    _ => _.contactInput.lastname,
    (_,e) => { _.contactInput.lastname = e.target.value },
    _ => _.contactInput.gender,
    (_,e) => { _.contactInput.gender = e.target.value },
    (_,e) => { _.addContact.call(_, e) },
    _ => [_.contactInput.firstname]
  ]
}
```
