### PR TITLE
fix(nuekit-server): allow resolving index.html with base url

### DIFF
--- a/packages/nuekit/src/nueserver.js
+++ b/packages/nuekit/src/nueserver.js
@@ -40,8 +40,10 @@ export function createServer(root, callback) {
       })
     }
 
-    const [ url, _ ] = req.url.split('?')
+    let [ url, _ ] = req.url.split('?')
     const ext = extname(url).slice(1)
+
+    if (!ext) url = join(url, 'index.html')
 
     try {
       const { code, path } = !ext || ext == 'html' ? await callback(url, _) : { path: url }


### PR DESCRIPTION
Fixes server not knowing index routes, e.g. `localhost:8080/blog` by adding `index.html` to links not having any extension, resulting in a file request to `localhost:8080/blog/index.html`