### PR TITLE
Fix cli init mkdir missing recursive: true and error message not showing

### DIFF
--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -117,7 +117,7 @@ if (args.help) {
   try {
     await runCommand(args)
   } catch (e) {
-    if (e.errno != -2) console.info(e)
+    console.info(e)
   }
 }
 

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -23,7 +23,7 @@ export async function init({ dist, is_dev, esbuild }) {
 
   } catch {
     await fs.rmdir(outdir, { recursive: true })
-    await fs.mkdir(outdir)
+    await fs.mkdir(outdir, { recursive: true })
     await fs.writeFile(latest, '')
   }
 


### PR DESCRIPTION
Apperance:
`$ nue` does nothing but exits

Steps to reproduce:
```sh
cd create-nue/simple-blog
nue  # here nue is linked from my local nue directory (nuekit@0.1.6 - 310d51f)
```

Before fix:
<img width="519" alt="image" src="https://github.com/nuejs/nue/assets/6647633/4886e9ce-0d0c-43a9-b471-68a267bdf747">

After fix:
<img width="377" alt="image" src="https://github.com/nuejs/nue/assets/6647633/ed8d46e1-2f14-405a-85c7-e75740a337d4">
