### PR TITLE
Fix back button popstate not working on the first pushState

### DIFF
--- a/packages/nuekit/src/browser/page-router.js
+++ b/packages/nuekit/src/browser/page-router.js
@@ -69,6 +69,11 @@ export function setSelected(path, className='selected') {
 }
 
 
+// Fix: window.onpopstate, event.state == null?
+// https://stackoverflow.com/questions/11092736/window-onpopstate-event-state-null
+is_browser && history.pushState({ path: location.pathname }, 0)
+
+
 // autoroute / document clicks
 is_browser && onclick(document, (path) => {
   loadPage(path)


### PR DESCRIPTION
Apperance:
The back button does not work right after the first link navigation, but begins to work after the second navigation.
( Tried Chrome 120.0.6099.129 and Safari 16.6 (17615.3.12.11.3, 17615) )

Reason:
The first popstate e.state=null, and getting path=undefined
<img width="1396" alt="image" src="https://github.com/nuejs/nue/assets/6647633/88a086b0-d0df-4bc6-b121-64881a51a222">

Steps to reproduce:
```sh
cd simple-blog
# both
nue
# and
nue build --production
nue serve --production
```

Fix Approach:
~~Record the `initial_path` and use it when path is undefined.~~

~~Or maybe, just `loadPage(location.pathname)`, regardless of e.state.path ? ref: https://github.com/fritx/silent/blob/2x/blog/vendor/blog.js#L409-L413~~

ref: window.onpopstate, event.state == null?
https://stackoverflow.com/questions/11092736/window-onpopstate-event-state-null