### PR TITLE
feat: title_template config key

### DIFF
--- a/packages/nuekit/src/layout.js
+++ b/packages/nuekit/src/layout.js
@@ -5,6 +5,7 @@ export function renderHead(data, is_prod) {
     viewport    = 'width=device-width,initial-scale=1',
     generator   = 'Nue (nuejs.org)',
     charset     = 'utf-8',
+    title_template = '%s',
     scripts     = [],
     styles      = [],
     inline_css  = [],
@@ -18,7 +19,7 @@ export function renderHead(data, is_prod) {
   } = data
 
   const head = [`<meta charset="${charset}">`]
-  if (title) head.push(`<title>${title}</title>`)
+  if (title) head.push(`<title>${title_template.replace(/%s/gi, title)}</title>`)
 
   // meta
   const pushMeta = (key, val) => val && head.push(`<meta name="${key}" content="${val}">`)


### PR DESCRIPTION
This allows to make titles in the format you like, e.g. containing site name.

The config could look like this:

```yaml
# site.yaml
title_template: '%s | My Site Name'
```
