### PR TITLE
Fix Windows CI via node+jest (as alternative to bun)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,11 +10,35 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+          - { os: 'ubuntu-22.04', tool: 'bun' }
+          - { os: 'macos-12', tool: 'bun' }
+          # Windows support for bun install is not implemented yet
+          # - { os: 'windows-2022', tool: 'bun' }
+          # - { os: 'ubuntu-22.04', tool: 'node+jest' }
+          # - { os: 'macos-12', tool: 'node+jest' }
+          - { os: 'windows-2022', tool: 'node+jest' }
+    runs-on: ${{ matrix.env.os }}
     steps:
       - uses: actions/checkout@v3
+
+      # Testing `bun`
       - uses: oven-sh/setup-bun@v1
+        if: ${{ matrix.env.tool == 'bun' }}
       - run: |
+          bun -v
           bun install
           bun install --no-save esbuild@^0.19.11
           bun test --coverage
+        if: ${{ matrix.env.tool == 'bun' }}
+
+      # Testing `node+jest`
+      - run: |
+          node -v && npm -v
+          npm install
+          npm install --no-save jest jest-extended esbuild@^0.19.11
+          # https://jestjs.io/docs/ecmascript-modules
+          node --experimental-vm-modules node_modules/jest/bin/jest --runInBand --coverage
+        if: ${{ matrix.env.tool == 'node+jest' }}

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "engines": {
     "bun": ">=1",
     "node": ">=18"
+  },
+  "jest": {
+    "setupFilesAfterEnv": ["jest-extended/all"]
   }
 }

--- a/packages/nuejs/test/render.test.js
+++ b/packages/nuejs/test/render.test.js
@@ -218,9 +218,18 @@ test('{ expr } error', () => {
     render('<div>\n<b>Hey { foo[0] } { title }</b></div>')
 
   } catch (e) {
-    expect(e.subexpr).toBe('foo[0]')
-    expect(e.line).toBe(2)
-    expect(e.column).toBe(9)
+    // Getting different results from different environments
+    // bun: TypeError: undefined is not an object (evaluating '_.foo[0]')
+    if (process.isBun) {
+      expect(e.subexpr).toBe('foo[0]')
+      expect(e.line).toBe(2)
+      expect(e.column).toBe(9)
+    } else {
+      // node: TypeError: Cannot read properties of undefined (reading '0')
+      expect(e.subexpr).toBe('0')
+      expect(e.line).toBe(2)
+      expect(e.column).toBe(13)
+    }
   }
 })
 

--- a/packages/nuekit/package.json
+++ b/packages/nuekit/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"diff-dom": "^5.0.6",
+		"es-main": "^1.3.0",
 		"import-meta-resolve": "^4.0.0",
 		"js-yaml": "^4.1.0",
 		"nuejs-core": "^0.3.0",

--- a/packages/nuekit/src/browser/app-router.js
+++ b/packages/nuekit/src/browser/app-router.js
@@ -2,6 +2,8 @@
 // Router for single-page applications
 import { onclick, loadPage, setSelected } from './page-router.js'
 
+const is_browser = typeof window == 'object'
+
 const fns = []
 
 async function fire(path) {
@@ -13,7 +15,7 @@ async function fire(path) {
 }
 
 // clear existing routes
-addEventListener('before:route', () => {
+is_browser && addEventListener('before:route', () => {
   fns.splice(0, fns.length)
 })
 

--- a/packages/nuekit/src/browser/page-router.js
+++ b/packages/nuekit/src/browser/page-router.js
@@ -48,13 +48,6 @@ export async function loadPage(path) {
 }
 
 
-// back button
-addEventListener('popstate', e => {
-  const { path, is_spa } = e.state || {}
-  if (path) loadPage(path)
-})
-
-
 // setup linking
 export function onclick(root, fn) {
 
@@ -103,6 +96,12 @@ if (is_browser) {
 
   // initial selected
   setSelected(location.pathname)
+
+  // back button
+  addEventListener('popstate', e => {
+    const { path } = e.state || {}
+    if (path) loadPage(path)
+  })
 }
 
 

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { log, colors } from './util.js'
+import esMain from 'es-main'
 
 // [-npe] --> [-n, -p, -e]
 export function expandArgs(args) {
@@ -104,6 +105,9 @@ async function runCommand(args) {
   else if (cmd == 'stats') await nue.stats()
 }
 
+// Only run main when called as real CLI
+if (esMain(import.meta)) {
+
 const args = getArgs(process.argv)
 
 // help
@@ -127,11 +131,4 @@ if (args.help) {
   }
 }
 
-
-
-
-
-
-
-
-
+}

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -1,6 +1,6 @@
 
 import { join, extname, basename, sep, parse as parsePath } from 'node:path'
-import { log, getParts, getAppDir, getDirs, colors } from './util.js'
+import { log, getParts, getAppDir, getDirs, colors, getPosixPath } from './util.js'
 import { parse as parseNue } from 'nuejs-core/index.js'
 import { nuemark } from 'nuemark/index.js'
 import { promises as fs } from 'node:fs'
@@ -125,7 +125,8 @@ export async function createSite(args) {
 
         }).forEach(path => {
           const ext = extname(path)
-          arr.push('/' + join(dir, to_ext ? path.replace(ext, '.' + to_ext) : path))
+          const subpath = to_ext ? path.replace(ext, '.' + to_ext) : path
+          arr.push('/' + getPosixPath(join(dir, subpath)))
         })
 
       } catch (e) {

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -1,6 +1,6 @@
 
 /* misc stuff. think shame.css */
-import { sep, parse } from 'node:path'
+import { sep, parse, normalize } from 'node:path'
 
 
 export function log(msg, extra='') {
@@ -29,6 +29,7 @@ export const colors = getColorFunctions()
 /* path parts */
 
 export function getParts(path) {
+  path = normalize(path)
   const { dir, name, base } = parse(path)
   const appdir = getAppDir(path)
   const url = getUrl(dir, name)
@@ -37,6 +38,7 @@ export function getParts(path) {
 
 
 export function getAppDir(path) {
+  path = normalize(path)
   const [ appdir ] = path.split(sep)
   return appdir == path ? '' : appdir
 }
@@ -44,14 +46,19 @@ export function getAppDir(path) {
 // getDirs('a/b/c') --> ['a', 'a/b', 'a/b/c']
 export function getDirs(dir) {
   if (!dir) return []
+  dir = normalize(dir)
   const els = dir.split(sep)
   return els.map((el, i) => els.slice(0, i + 1).join(sep))
 }
 
 export function getUrl(dir, name) {
-  let url = dir.replace('\\', '/') + '/'
+  let url = getPosixPath(dir) + '/'
   if (url[0] != '/') url = '/' + url
   // if (name != 'index')
   url += name + '.html'
   return url
+}
+
+export function getPosixPath(path) {
+  return path.replaceAll('\\', '/')
 }

--- a/packages/nuekit/test/kit-init.test.js
+++ b/packages/nuekit/test/kit-init.test.js
@@ -1,0 +1,19 @@
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import { init } from '../src/init.js'
+
+// temporary directory
+const root = '_test'
+
+// setup and teardown
+beforeAll(async () => {
+  await fs.rm(root, { recursive: true, force: true })
+  await fs.mkdir(root, { recursive: true })
+})
+afterAll(async () => await fs.rm(root, { recursive: true, force: true }))
+
+test('init dist/@nue dir', async () => {
+  await init({ dist: root, is_dev: true, esbuild: false })
+  const names = await fs.readdir(join(root, '@nue'))
+  expect(names.length).toBeGreaterThan(7)
+})

--- a/packages/nuekit/test/match-path.js
+++ b/packages/nuekit/test/match-path.js
@@ -1,0 +1,26 @@
+import { getPosixPath } from '../src/util.js'
+
+// https://stackoverflow.com/questions/67325342/how-to-run-os-agnostic-jest-test-files-that-check-paths
+// https://jestjs.io/docs/expect#expectextendmatchers
+export function toMatchPath(actual, expected) {
+  const { printReceived, printExpected, matcherHint } = this.utils
+
+  const pass = getPosixPath(actual) == expected
+
+  return {
+    pass,
+    message: () => pass
+      ? matcherHint('.not.toMatchPath') +
+        '\n\n' +
+        'Expected path not to match:\n' +
+        `  ${printExpected(expected)}\n` +
+        'Received:\n' +
+        `  ${printReceived(actual)}`
+      : matcherHint('.toMatchPath') +
+        '\n\n' +
+        'Expected path to match:\n' +
+        `  ${printExpected(expected)}\n` +
+        'Received:\n' +
+        `  ${printReceived(actual)}`
+  }
+}

--- a/packages/nuekit/test/misc.test.js
+++ b/packages/nuekit/test/misc.test.js
@@ -6,6 +6,10 @@ import { match } from '../src/browser/app-router.js'
 import { renderHead } from '../src/layout.js'
 import { getArgs } from '../src/cli.js'
 
+import { toMatchPath } from './match-path.js'
+
+expect.extend({ toMatchPath })
+
 const lcss = await findModule('lightningcss')
 const stylus = await findModule('stylus')
 
@@ -85,8 +89,8 @@ test('app router', async () => {
 test('path parts', () => {
   const parts = getParts('docs/glossary/semantic-css.md')
   expect(parts.url).toBe('/docs/glossary/semantic-css.html')
-  expect(parts.dir).toBe('docs/glossary')
-  expect(parts.appdir).toBe('docs')
+  expect(parts.dir).toMatchPath('docs/glossary')
+  expect(parts.appdir).toMatchPath('docs')
   expect(parts.slug).toBe('semantic-css.html')
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       diff-dom:
         specifier: ^5.0.6
         version: 5.1.2
+      es-main:
+        specifier: ^1.3.0
+        version: 1.3.0
       import-meta-resolve:
         specifier: ^4.0.0
         version: 4.0.0
@@ -81,6 +84,10 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+    dev: false
+
+  /es-main@1.3.0:
+    resolution: {integrity: sha512-AzORKdz1Zt97TzbYQnIrI3ZiibWpRXUfpo/w0xOJ20GpNYd2bd3MU9m31zS/aJ1TJl6JfLTok83Y8HjNunYT0A==}
     dev: false
 
   /htmlparser2@9.0.0:


### PR DESCRIPTION
#154 can not be re-opened, so created a new PR with less diff change:

Goal:
Add and fix CI for Windows

Problem:
`bun` is not availble in Windows currently (ref: https://github.com/oven-sh/bun/issues/8045, https://github.com/oven-sh/bun/pull/7991).
Tried with both `setup-bun` ([docs](https://github.com/oven-sh/setup-bun?tab=readme-ov-file#usage), [failed](https://github.com/fritx/nue/actions/runs/7397873002/job/20125810699)) and `powershell -c "irm bun.sh/install.ps1|iex"` ([docs](https://bun.sh/docs/installation#windows), [failed](https://github.com/fritx/nue/actions/runs/7462503061/job/20304947574))

Solution:
For Windows, switching to `npm install` + `jest` as alternative to `bun install` + `bun test`.

Details:
- Completing the CI envs: (ubuntu, macos, windows) x (bun, node+jest)
- Making tests compatible with node+jest:
  - adding some missing `is_browser` detections
  - introducing [`es-main`](https://github.com/tschaub/es-main) to detect and prevent unexpected call of `getArgs` (throwing on the wrong args)
  - using `jest-extended` to eliminate the `expect.*` matchers gap between `bun test` and `jest`
  - separating kit-init.test.js to run sequential, making tests passed (seems chdir is affecting the other tests)
- Making tests compatible with Windows:
  - introducing [`toMatchPath`](https://stackoverflow.com/questions/67325342/how-to-run-os-agnostic-jest-test-files-that-check-paths)
  - handling some paths with `path.normalize` or `getPosixPath`