### PR TITLE
test: only run actions on master

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,13 @@
 name: Test
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only run tests on commits / PRs to branch `master` or on manual dispatch from actions tab.
This prevents unnecessary runs and therefore saves action time usage.

Also, people typically don't do commits to the default branch of a fork, which also prevents workflows from running in their forked repo.
And if they have to, they can still run the workflow manually.

---

Just adding the billable time as a note: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes

> GitHub Free for organizations: **2,000 minutes** (per month)

Operating system | Minute multiplier
--- | ---
Linux | 1
Windows | 2
macOS | 10

I mean, this won't really ever get hit. If we think of 30 days in a month:
$\frac{2000}{30}=66.\overline{6}$ minutes per day... which is won't be reached realistically. We take about 5 seconds for a run with this workflow. Even if there are more workflows...