### PR TITLE
test(nuekit): drop removed function from tests

### DIFF
--- a/packages/nuekit/test/misc.test.js
+++ b/packages/nuekit/test/misc.test.js
@@ -1,7 +1,7 @@
 
 
 import { buildCSS, findModule } from '../src/builder.js'
-import { parseMarkdown, getParts } from '../src/util.js'
+import { getParts } from '../src/util.js'
 import { match } from '../src/browser/app-router.js'
 import { renderHead } from '../src/layout.js'
 import { getArgs } from '../src/cli.js'
@@ -73,13 +73,6 @@ test('head', () => {
   expect(head).toInclude('meta charset="foo"')
   expect(head).toInclude('<title>Hey</title>')
   expect(head).toInclude('<link rel="preload" as="image" href="hey.png">')
-})
-
-
-test('markdown', async () => {
-  const { meta, content } = parseMarkdown('---\nog: og.png\n---\n# Hey')
-  expect(meta.og).toBe('og.png')
-  expect(content.trim()).toBe('<h1>Hey</h1>')
 })
 
 test('app router', async () => {


### PR DESCRIPTION
The tests fail, because a removed function `parseMarkdown` (now handled by `nuemark`) is imported by the test file `nuekit/test/misc.test.js`.

See the workflow run test log https://github.com/nuejs/nue/actions/runs/7500154128/job/20418283484#step:4:106

Should also solve the red badge in the README mentioned here: https://github.com/nuejs/nue/pull/155#issuecomment-1888722726