### PR TITLE
chore: drop `Permalink for` for now

### DIFF
--- a/packages/nuemark/src/render.js
+++ b/packages/nuemark/src/render.js
@@ -125,7 +125,7 @@ const renderer = {
     const rich = parseHeading(html)
 
     delete plain.text
-    const a = elem('a', { href: `#${plain.id}`, title: `Permlink for '${title}'` })
+    const a = elem('a', { href: `#${plain.id}`, title: `Permalink for '${title}'` })
     return elem(`h${level}`, plain, a + rich.text)
   },
 

--- a/packages/nuemark/src/render.js
+++ b/packages/nuemark/src/render.js
@@ -125,7 +125,7 @@ const renderer = {
     const rich = parseHeading(html)
 
     delete plain.text
-    const a = elem('a', { href: `#${plain.id}`, title: `Permalink for '${title}'` })
+    const a = elem('a', { href: `#${plain.id}`, title: title })
     return elem(`h${level}`, plain, a + rich.text)
   },
 


### PR DESCRIPTION
This is just a minimal typo fix.

But I see a problem with this approach, as the `title` property is hard-coded this way.

What if I want to create a Website not in English? (I do.) Then the `Permalink for 'x'` approach doesn't work anymore.

In conclusion, my concern is the localizability.

---

*Tests will run properly again after #162 is merged.*