### PR TITLE
Fix esbuild module resolve and missing parameter passing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,38 @@ Please try to use the original style in the codebase. Do not introduce new rules
 Nue is not using Prettier or ESLint because they will increase the project size to 40MB. The `.prettierrc.yaml` file on the root directory does the job well enough.
 
 
+### Testing
+
+```sh
+# if using bun
+bun install
+bun install --no-save esbuild
+bun test
+
+# if using node
+npm install
+npm install --no-save jest jest-extended esbuild
+node --experimental-vm-modules node_modules/jest/bin/jest --runInBand
+```
 
 
+### Linking
 
+```sh
+# if using bun
+bun install
+cd packages/nuekit
+bun link
+cd my/nue/project
+nue
+nue build --production
+
+# if using node
+npm install
+cd packages/nuekit
+npm link
+cd my/nue/project
+npm install --save-dev esbuild
+node $(which nue)
+node $(which nue) build --production
+```

--- a/packages/nuekit/package.json
+++ b/packages/nuekit/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"diff-dom": "^5.0.6",
+		"import-meta-resolve": "^4.0.0",
 		"js-yaml": "^4.1.0",
 		"nuejs-core": "^0.3.0",
 		"nuemark": "^0.1.0"

--- a/packages/nuekit/src/builder.js
+++ b/packages/nuekit/src/builder.js
@@ -2,10 +2,11 @@
 /* Builders for CSS, JS, and TS */
 
 import { join, extname } from 'node:path'
+import { resolve } from 'import-meta-resolve'
 
 export async function getBuilder(is_esbuild) {
   try {
-    return is_esbuild ? await import('esbuild') : Bun
+    return is_esbuild ? await import(await resolve('esbuild', `file://${process.cwd()}/`)) : Bun
   } catch {
     throw 'Bundler not found. Please use Bun or install esbuild'
   }

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -44,6 +44,7 @@ export function getArgs(argv) {
       else if (['-h', '--help'].includes(arg)) args.help = true
       else if (['-v', '--verbose'].includes(arg)) args.verbose = true
       else if (['-s', '--stats'].includes(arg)) args.stats = true
+      else if (['-b', '--esbuild'].includes(arg)) args.esbuild = true
 
       // string values
       else if (['-e', '--environment'].includes(arg)) opt = 'env'

--- a/packages/nuekit/src/nuekit.js
+++ b/packages/nuekit/src/nuekit.js
@@ -19,7 +19,7 @@ const DOCTYPE = '<!doctype html>\n\n'
 const NOT_FOUND = -2
 
 export async function createKit(args) {
-  const { root, is_prod, env } = args
+  const { root, is_prod, esbuild } = args
 
   // site: various file based functions
   const site = await createSite(args)
@@ -28,7 +28,7 @@ export async function createKit(args) {
   const is_dev = !is_prod
 
   // make sure @nue dir has all the latest
-  if (!args.dryrun) await init({ dist, is_dev })
+  if (!args.dryrun) await init({ dist, is_dev, esbuild })
 
 
 
@@ -186,6 +186,7 @@ export async function createKit(args) {
     await buildJS({
       outdir: join(process.cwd(), dist, file.dir),
       path: join(process.cwd(), root, path),
+      esbuild,
       minify: is_prod,
       bundle
     })


### PR DESCRIPTION
Steps to reproduce the bug:
```sh
cd create-www/simple-crm
echo {} > package.json
npm install --dev esbuild
node $(which nue)
# ok
node $(which nue) build --production
# error: Bundler not found. Please use Bun or install esbuild
```

__1. Fixed esbuild module resolve and missing parameter passing__

- introduced [`import-meta-resolve`](https://npmjs.com/import-meta-resolve), because `import.meta.resolve` doesn't work for me
- manually tested linking and `nue build --production --esbuild` under both node and bun

__2. Added Testing and Linking guide to Contributing docs__

I found I can only link by `bun link` or `npm link` to develop and test nuekit locally.

If you guys can do it via `pnpm link`, pls let me know :)

`pnpm link`+`node $(which nue)` (as documented in [official docs](https://nuejs.org/docs/#node)) is not working:
![WX20240115-124007](https://github.com/nuejs/nue/assets/6647633/dcd4ca58-d1e2-4691-ab67-eb907c465f26)

```sh
# /Users/fritx/Library/pnpm/nue
#!/bin/sh
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")

case `uname` in
    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
esac

if [ -z "$NODE_PATH" ]; then
  export NODE_PATH="/Users/fritx/g/nue/packages/nuekit/src/node_modules:/Users/fritx/g/nue/packages/nuekit/node_modules:/Users/fritx/g/nue/packages/node_modules:/Users/fritx/g/nue/node_modules:/Users/fritx/g/node_modules:/Users/fritx/node_modules:/Users/node_modules:/node_modules:/Users/fritx/Library/pnpm/global/5/.pnpm/node_modules"
else
  export NODE_PATH="/Users/fritx/g/nue/packages/nuekit/src/node_modules:/Users/fritx/g/nue/packages/nuekit/node_modules:/Users/fritx/g/nue/packages/node_modules:/Users/fritx/g/nue/node_modules:/Users/fritx/g/node_modules:/Users/fritx/node_modules:/Users/node_modules:/node_modules:/Users/fritx/Library/pnpm/global/5/.pnpm/node_modules:$NODE_PATH"
fi
if [ -x "$basedir/bun" ]; then
  exec "$basedir/bun"  "$basedir/global/5/node_modules/nuekit/src/cli.js" "$@"
else
  exec bun  "$basedir/global/5/node_modules/nuekit/src/cli.js" "$@"
fi
```