### PR TITLE
fix(code-block): escape html chars to text content

### DIFF
--- a/packages/nuemark/src/render.js
+++ b/packages/nuemark/src/render.js
@@ -59,10 +59,20 @@ export function renderLines(lines, opts={}) {
   return renderPage(page, opts)
 }
 
+const specialChars = {
+  '&': '&amp;',
+  '>': '&gt;',
+  '<': '&lt;',
+  '"': '&quot;',
+  "'": '&apos;',
+}
+
+const replaceSpecialChars = new RegExp(`[${Object.keys(specialChars).join('')}]`, 'g')
+
 export function renderCodeBlock({ name, code, attr }, fn) {
   // console.info(name, code, attr, fn)
   if (name) attr.class = concat(`syntax-${name}`, attr.class)
-  const body = join(code)
+  const body = join(code).replace(replaceSpecialChars, c => specialChars[c])
 
   return elem('pre', attr, fn ? fn(body) : body)
 }


### PR DESCRIPTION
Partial fix for #168

Escapes chars from code blocks to prevent them from being parsed as HTML.

This is not ideal, as code markup parsers have to then check for replaced char codes.

But replacing after running the `fn` function is also not great, because it potentially appends real HTML parts (e.g., `<span>`s) to do, for example, highlighting.
