### PR TITLE
Fix parseExpr in case of single quote in str, and nueserver...

### DIFF
--- a/packages/nuejs/src/expr.js
+++ b/packages/nuejs/src/expr.js
@@ -35,7 +35,7 @@ export function parseExpr(str, is_style) {
 
     // normal string
     if (i % 2 == 0) {
-      if (str) ret.push(`'${str}'`)
+      if (str) ret.push(str.includes("'") ? JSON.stringify(str) : `'${str}'`)
 
     // Object: { is-active: isActive() }
     } else if (isObject(str.trim())) {

--- a/packages/nuejs/test/parse.test.js
+++ b/packages/nuejs/test/parse.test.js
@@ -46,6 +46,7 @@ test('Expressions', () => {
 
   runTests(parseExpr, {
     'Hey { name }': [ "'Hey '", '_.name' ],
+    "Hey, I'm { name }": [ '"Hey, I\'m "', '_.name' ],
     'foo { alarm } is-alert': [ "'foo '", '_.alarm', "' is-alert'" ],
     'is-cool { danger: hasError }': [ "'is-cool '", "_.hasError && 'danger '" ],
 

--- a/packages/nuekit/src/nueserver.js
+++ b/packages/nuekit/src/nueserver.js
@@ -48,8 +48,9 @@ export function createServer(root, callback) {
     try {
       const { code, path } = !ext || ext == 'html' ? await callback(url, _) : { path: url }
       if (!path) throw { errno: -2 }
+      const buffer = await fs.readFile(join(root, path))
       res.writeHead(code || 200, { 'content-type': TYPES[ext] || TYPES.html })
-      res.end(await fs.readFile(join(root, path)))
+      res.end(buffer)
   
     } catch(e) {
       const nf = e.errno == -2 // not found


### PR DESCRIPTION
1. Fix parseExpr in case of single quote in str
![image](https://github.com/nuejs/nue/assets/6647633/ae8ba737-2564-449b-8ff7-1a176d1b39f5)


2. Fix ERR_HTTP_HEADERS_SENT if files like favicon.ico not found in nueserver
![image](https://github.com/nuejs/nue/assets/6647633/b2eaf5ad-331c-45ca-a843-f0f1c9a78faf)
