### PR TITLE
Handle missing pubDate while sorting

### DIFF
--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -180,7 +180,15 @@ export async function createSite(args) {
       arr.push({ ...meta, ...getParts(path) })
     }
 
-    arr.sort((a, b) => b.pubDate - a.pubDate)
+    arr.sort((...args) => {
+      // pubDate can be undefined, converting to integers to compare
+      const [d1, d2] = args.map(data => new Date(data.pubDate).getTime() || -1)
+      const [t1, t2] = args.map(data => data.title)
+      if (d2 - d1 == 0) {
+        return t2 > t1 ? 1 : t2 < t1 ? -1 : 0
+      }
+      return d2 - d1
+    })
     if (is_bulk) cache[key] = arr
     return arr
   }

--- a/packages/nuekit/test/nuekit.test.js
+++ b/packages/nuekit/test/nuekit.test.js
@@ -121,7 +121,7 @@ test('get data', async () => {
 
 test('content collection', async () => {
   // Default sorting is on pubDate returning most recent first.
-  await write('blog/first-a.md', '# First')
+  await write('blog/first-a.md', createFront('First'))
   await write('blog/first-b.md', createFront('Second', '2020-01-04'))
   await write('blog/nested/hey1.md', createFront('Third', '2020-01-02'))
   await write('blog/nested/hey2.md', createFront('Fourth', '2020-01-03'))
@@ -133,8 +133,8 @@ test('content collection', async () => {
   expect(actual).toEqual([
     { url: '/blog/first-a.html', title: 'First', dir: 'blog', slug: 'first-a.html' },
     { url: '/blog/first-b.html', title: 'Second', dir: 'blog', slug: 'first-b.html' },
-    { url: '/blog/nested/hey2.html', title: 'Fourth', dir: 'blog/nested', slug: 'hey2.html' },
-    { url: '/blog/nested/hey1.html', title: 'Third', dir: 'blog/nested', slug: 'hey1.html' },
+    { url: '/blog/nested/hey2.html', title: 'Fourth', dir: join('blog', 'nested'), slug: 'hey2.html' },
+    { url: '/blog/nested/hey1.html', title: 'Third', dir: join('blog', 'nested'), slug: 'hey1.html' },
   ])
 })
 

--- a/packages/nuekit/test/nuekit.test.js
+++ b/packages/nuekit/test/nuekit.test.js
@@ -121,6 +121,10 @@ test('get data', async () => {
 
 test('content collection', async () => {
   // Default sorting is on pubDate returning most recent first.
+  await write('blog/without-front-d.md', '# dddd')
+  await write('blog/without-front-a.md', '# a')
+  await write('blog/without-front-c.md', '# ccc')
+  await write('blog/without-front-b.md', '# bb')
   await write('blog/first-a.md', createFront('First'))
   await write('blog/first-b.md', createFront('Second', '2020-01-04'))
   await write('blog/nested/hey1.md', createFront('Third', '2020-01-02'))
@@ -135,6 +139,10 @@ test('content collection', async () => {
     { url: '/blog/first-b.html', title: 'Second', dir: 'blog', slug: 'first-b.html' },
     { url: '/blog/nested/hey2.html', title: 'Fourth', dir: join('blog', 'nested'), slug: 'hey2.html' },
     { url: '/blog/nested/hey1.html', title: 'Third', dir: join('blog', 'nested'), slug: 'hey1.html' },
+    { url: '/blog/without-front-d.html', title: 'dddd', dir: 'blog', slug: 'without-front-d.html' },
+    { url: '/blog/without-front-c.html', title: 'ccc', dir: 'blog', slug: 'without-front-c.html' },
+    { url: '/blog/without-front-b.html', title: 'bb', dir: 'blog', slug: 'without-front-b.html' },
+    { url: '/blog/without-front-a.html', title: 'a', dir: 'blog', slug: 'without-front-a.html' },
   ])
 })
 


### PR DESCRIPTION
Commits based on PR #190 

1. Sort by title when pubDate is missing (pubDate defaults to -1 , comparing with existing dates). Thoughts?
2. Complete the test-cases for no front provided