### PR TITLE
For discussion of issue #198 (dont merge!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 dist
 .idea
+.vscode
+_test

--- a/packages/nuekit/src/isLegit.js
+++ b/packages/nuekit/src/isLegit.js
@@ -1,0 +1,15 @@
+/** Returns a function that will check if a file is not ignored and is legit.*/
+export function makeIsLegit(ignores = []) {
+    const IGNORE = ['node_modules', 'package.json', 'bun.lockb', 'pnpm-lock.yaml', ...ignores]  
+  
+    function ignore(name='') {
+      return '._'.includes(name[0]) || IGNORE.includes(name)
+    }
+    
+    function isLegit(file) {
+      return !ignore(file.name) && !ignore(file.dir)
+    }
+    
+    // TODO: real symdir detection
+    return isLegit
+  }

--- a/packages/nuekit/src/nuekit.js
+++ b/packages/nuekit/src/nuekit.js
@@ -360,7 +360,7 @@ export async function createKit(args) {
   }
 
   async function stats() {
-    const rows = await readStats(dist, site.globals)
+    const rows = await readStats(site.isLegit, dist, site.globals)
     printTable(['Page', 'HTML', 'CSS', 'JS'], rows)
     return rows
   }

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -121,7 +121,7 @@ export async function createSite(args) {
 
     for (const dir of dirs) {
       try {
-        const paths = self.globals.includes(dir) ? await fswalk(self.isLegit, join(root, isLegit, dir)) : await fs.readdir(join(root, dir))
+        const paths = self.globals.includes(dir) ? await fswalk(self.isLegit, join(root, self.isLegit, dir)) : await fs.readdir(join(root, dir))
 
         paths.filter(path => {
           const ext = extname(path).slice(1)

--- a/packages/nuekit/src/stats.js
+++ b/packages/nuekit/src/stats.js
@@ -9,8 +9,8 @@ async function readSize(dist, path) {
   return raw.length
 }
 
-export async function readStats(dist, globals) {
-  const paths = await fswalk(dist)
+export async function readStats(isLegit, dist, globals) {
+  const paths = await fswalk(isLegit, dist)
 
   async function getSize(appdir, ext) {
     let total = 0


### PR DESCRIPTION
In order to add support for including optional IGNORE settings in `site.yaml`, It is necessary to make some rather large changes to 

- nuefs.js (specifically the critical `fswalk`)
- nuekit.js
-  site.js
- fswalk 

... due to the various hidden dependancies surrounging isLegit and the whole configuration merging.

In order to make the changes i've also had to move isLegit out to a separate file and create a factory method to return an "isLegit" function to avoid having to pass the "ignores" with every invocation.

I'm not comfortable that this is the right way to inject global configuration/settings, and that some of the existing bootstrapping might need discussing and re-thinking.

I've created  a PR so that these changes can be easily shared and discussed. 

### Changes to critical `fswalk`

This PR also shows that allowing user configurations in site.yaml related to files, ends up requiring delicate changes to `fswalk`, a critical piece of code that we need to limit changes to. (imho) 

### Hard code support for Cloudflare and leave user configuration for the next major release

Coverage is currently low; therefore for now, I recommend hard coding in support for excluding cloudflare worker functions folder, but leaving out the ability to customise it further with configurations in site.yaml.

I think a change to injecting global configuration settings requires a discussion, and might end up rethinking bootstrapping and be better to wait to include in a next major release? (hard coding solid good defaults for pit-of-sucess and idiot proofing the first version)

Hopefully the code changes in the discussion branch make sense; but it's a fairly chunky bit of changes, so I'll happy answer any questions if that will help.

I think that adding any other user overridable settings (in site.yaml) would end up requiring very similar changes, hence this PR for discussion only. 

Your thoughts?
Alan

p.s. I've got all the tests passing here. So while this branch is for discussion, it's passing all the tests.
I had to change the `beforeAll` and `AfterAll` to `beforeEach` and `AfterEach`, because some tests overwrite the site.yaml, and cause side effects. I though it would slow down the tests, but BUN is just unbelievably fast and didnt slow down at all. Having that nice clean separation for these integration tests is important.

After we've discussed this ... I'll create a new PR for hard coding support for ringfencing (protecting) cloudflare `functions` folder, and update the tests and bring in the `beforeEach` and `afterEach` change into that PR.