### PR TITLE
Again! Fix the failed CI

### DIFF
--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -94,6 +94,7 @@ async function resolvePath(npm_path) {
   const [ npm_name, ...parts ] = npm_path.split('/')
   let main = await resolve(npm_name, `file://${process.cwd()}/`)
   main = main.replace(/^file:\/\//, '')
+  main = process.platform === 'win32' && main.startsWith('/') ? main.slice(1) : main
   return main.replace('index.js', parts.join('/'))
 }
 

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -2,6 +2,7 @@
 import { compileFile as nueCompile} from 'nuejs-core'
 import { join, basename } from 'node:path'
 import { promises as fs } from 'node:fs'
+import { resolve } from 'import-meta-resolve'
 import { buildJS } from './builder.js'
 import { colors } from './util.js'
 
@@ -91,7 +92,8 @@ export async function init({ dist, is_dev, esbuild }) {
 
 async function resolvePath(npm_path) {
   const [ npm_name, ...parts ] = npm_path.split('/')
-  const main = await import.meta.resolve(npm_name)
+  let main = await resolve(npm_name, `file://${process.cwd()}/`)
+  main = main.replace(/^file:\/\//, '')
   return main.replace('index.js', parts.join('/'))
 }
 

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -180,7 +180,10 @@ export async function createSite(args) {
       arr.push({ ...meta, ...getParts(path) })
     }
 
-    arr.sort((a, b) => b.pubDate - a.pubDate)
+    arr.sort((a, b) => {
+      const [d1, d2] = [a, b].map(v => v.pubDate || Infinity)
+      return d2 - d1
+    })
     if (is_bulk) cache[key] = arr
     return arr
   }

--- a/packages/nuekit/test/nuekit.test.js
+++ b/packages/nuekit/test/nuekit.test.js
@@ -144,8 +144,8 @@ test('content collection', async () => {
   expect(actual).toEqual([
     { pubDate: undefined, url: '/blog/first-a.html', title: 'First', dir: 'blog', slug: 'first-a.html' },
     { pubDate: new Date('2020-01-04'), url: '/blog/first-b.html', title: 'Second', dir: 'blog', slug: 'first-b.html' },
-    { pubDate: new Date('2020-01-03'), url: '/blog/nested/hey2.html', title: 'Fourth', dir: 'blog/nested', slug: 'hey2.html' },
-    { pubDate: new Date('2020-01-02'), url: '/blog/nested/hey1.html', title: 'Third', dir: 'blog/nested', slug: 'hey1.html' },
+    { pubDate: new Date('2020-01-03'), url: '/blog/nested/hey2.html', title: 'Fourth', dir: join('blog', 'nested'), slug: 'hey2.html' },
+    { pubDate: new Date('2020-01-02'), url: '/blog/nested/hey1.html', title: 'Third', dir: join('blog', 'nested'), slug: 'hey1.html' },
   ])
 })
 


### PR DESCRIPTION
✅ CI is now passing again:
~~https://github.com/fritx/nue/actions/runs/8000550563~~
https://github.com/fritx/nue/actions/runs/8000785880

1. [Attempt to pass the CI by handling missing pubDate while sorting](https://github.com/nuejs/nue/commit/6f78c2c1fe45a099568bb789de1e927aaa5ce9bf)
1. [Attempt to pass the Windows CI by adapting dir path](https://github.com/nuejs/nue/commit/71ccbb06e1ea4e0f74706e92f93fe723744ae9ae)
1. [Attempt to pass the (Node) CI by replacing import.meta.resolve](https://github.com/nuejs/nue/commit/b168151952ecc80c7b799a01208bc2eeba4f4c77)
    - Tried `import.meta.resolve` iwth both Node@18.18 and Node@18.19.1 in CI but failed.
    - While running `*.mjs` with `import.meta.resolve` is fine with Node@18.19.1 locally. Any one knows why?
 1. [Attempt to pass the Windows CI by removing the leading slash from absolute path](https://github.com/nuejs/nue/commit/a67f83d64827f905089bf9c4d8274674c6cecfbd) 
   - The logic appears in several places and can be extracted in the future, maybe next PR.