### PR TITLE
"nullnull" when some page parts are missing

### DIFF
--- a/packages/nuekit/src/browser/page-router.js
+++ b/packages/nuekit/src/browser/page-router.js
@@ -31,7 +31,7 @@ export async function loadPage(path) {
       a.remove()
 
     // add new one
-    } else {
+    } else if (b) {
       const fn = query == 'footer' ? 'append' : 'prepend'
       document.body[fn](b)
     }


### PR DESCRIPTION
not sure what behavior is expected when there is no header, main and footer at all.  in any of pages - old or new.  

it currently breaks the [simple-crm](https://github.com/nuejs/create-nue/tree/master/simple-crm) example because of that.   i came up with something like this:  
```js
  const parts = ["header", "main", "footer"]
    .map(query => [$("body >" + query), $("body2 >" + query, dom)]);
  if(parts.some(([a, _]) => a) && parts.some(([_, b]) => b)) {
    for (const [a,b] of parts) {
      if (a && b) {
        if (a.outerHTML != b.outerHTML)
          a.replaceWith(b);
      } else if (a) {
        a.remove();
      } else if (b) {
        const fn = query == "footer" ? "append" : "prepend";
        document.body[fn](b);
      }
    }
  } else {
    $('body').innerHTML = $('body2', dom).innerHTML;
  }
```
but most likely it's not what you meant 