### PR TITLE
fix: use `cwd` + `nue root` as base for relative file output path

### DIFF
--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -72,7 +72,7 @@ export async function createSite(args) {
     port = is_prod ? 8081 : 8080
   } = site_data
 
-  const dist = joinRootPath(root, rawDist || `.dist/${is_prod ? 'prod' : 'dev'}`)
+  const dist = joinRootPath(root, rawDist || join('.dist', is_prod ? 'prod' : 'dev'))
 
   // flag if .dist is empty
   try {

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -1,5 +1,5 @@
 
-import { log, getParts, getAppDir, getDirs, colors, toPosix, sortCSS } from './util.js'
+import { log, getParts, getAppDir, getDirs, colors, toPosix, sortCSS, joinRootPath } from './util.js'
 import { join, extname, basename, sep, parse as parsePath } from 'node:path'
 import { parse as parseNue } from 'nuejs-core'
 import { promises as fs } from 'node:fs'
@@ -68,10 +68,11 @@ export async function createSite(args) {
   }
 
   const {
-    dist = `${root}/.dist/${is_prod ? 'prod' : 'dev'}`,
+    dist: rawDist,
     port = is_prod ? 8081 : 8080
-
   } = site_data
+
+  const dist = joinRootPath(root, rawDist || `.dist/${is_prod ? 'prod' : 'dev'}`)
 
   // flag if .dist is empty
   try {

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -28,8 +28,8 @@ export const colors = getColorFunctions()
 
 /* path parts */
 
-export function joinRootPath(root, path) {
-  return join(isAbsolute(path) ? '' : root, path)
+export function joinRootPath(root, path, abs = false) {
+  return join(abs ? process.cwd() : '', isAbsolute(path) ? '' : root, path)
 }
 
 export function getParts(path) {

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -29,7 +29,7 @@ export const colors = getColorFunctions()
 /* path parts */
 
 export function joinRootPath(root, path) {
-  return join(isAbsolute(path) ? '' : join(process.cwd(), root), path)
+  return join(isAbsolute(path) ? '' : root, path)
 }
 
 export function getParts(path) {

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -1,6 +1,6 @@
 
 /* misc stuff. think shame.css */
-import { sep, parse, normalize } from 'node:path'
+import { sep, parse, normalize, join, isAbsolute } from 'node:path'
 
 
 export function log(msg, extra='') {
@@ -27,6 +27,10 @@ export const colors = getColorFunctions()
 
 
 /* path parts */
+
+export function joinRootPath(root, path) {
+  return join(isAbsolute(path) ? '' : join(process.cwd(), root), path)
+}
 
 export function getParts(path) {
   path = normalize(path)

--- a/packages/nuekit/test/nuekit.test.js
+++ b/packages/nuekit/test/nuekit.test.js
@@ -71,7 +71,7 @@ test('site.yaml', async () => {
   const site = await getSite()
 
   expect(site.globals).toEqual(['global'])
-  expect(site.dist).toBe('.mydist')
+  expect(site.dist).toBe('_test/.mydist')
   expect(site.port).toBe(1500)
 
   // teardown
@@ -83,7 +83,7 @@ test('environment', async () => {
   await write(env, 'dist: .alt')
   const site = await createSite({ root, env })
 
-  expect(site.dist).toBe('.alt')
+  expect(site.dist).toBe('_test/.alt')
   expect(site.port).toBe(8080)
 })
 


### PR DESCRIPTION
Allows to set paths relative to the root dir passed to the nue command instead of the cwd.
Also enables setting absolute paths

- [ ] Fix scripts not being copied/minified to the output folder :shrug:
- [ ] Tests, etc.
- [ ] There will always be something missing on some to-do list :)

Will have to investigate, why no `js` files are being copied.


EDIT: Ubuntu and Mac shouldn't be successful, as the paths are different from before...
Only Windows is correct with its test results...