### PR TITLE
fix: reference component using attribute

### DIFF
--- a/packages/nuejs/src/browser/nue.js
+++ b/packages/nuejs/src/browser/nue.js
@@ -2,6 +2,7 @@
 import For from './for.js'
 import If from './if.js'
 
+
 const CONTROL_FLOW = { ':if': If, ':for': For } // :if must be first
 const CORE_ATTR = ['class', 'style', 'id']
 
@@ -56,9 +57,10 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
         }
       }
 
-      const tagName = node.tagName.toLowerCase()
+      const tagName = getAttrRefComponent(node) || node.tagName.toLowerCase() 
       const next = node.nextSibling
 
+     
       // slot
       if (inner && tagName == 'slot') {
         inner.replace(node)
@@ -76,15 +78,16 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
           dom.append(...node.childNodes)
           child.inner = createApp({ fns, dom }, ctx, deps)
         }
-
+        
         const parent = createParent(node)
         const comp = createApp(child, ctx, deps, parent).mount(node)
-
         // Root node changes -> re-point to the new DOM element
-        if (dom?.tagName.toLowerCase() == child.name) self.$el = comp.$el
+        const tagName = getAttrRefComponent(dom) || dom?.tagName.toLowerCase()
+        if (tagName == child.name) {
+          self.$el = comp.$el
+        }
 
         expr.push(_ => setAttrs(comp.$el, parent))
-
         // component refs
         self.$refs[node.getAttribute('ref') || tagName] = comp.impl
 
@@ -238,7 +241,6 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
 
     mount(wrap) {
       const root = dom || (self.$el = mkdom(tmpl))
-
       // Isomorphic JSON. Saved for later hot-reloading
       let script = wrap.querySelector('script')
       if (script) {
@@ -359,3 +361,9 @@ function mergeVals(a, b) {
   return a.concat(b)
 }
 
+function getAttrRefComponent(node){
+  const attributeName = 'ref-component'; 
+  if(node && node.attributes)
+   return node.getAttribute(attributeName);
+  return null
+}

--- a/packages/nuejs/src/browser/nue.js
+++ b/packages/nuejs/src/browser/nue.js
@@ -82,15 +82,14 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
         const parent = createParent(node)
         const comp = createApp(child, ctx, deps, parent).mount(node)
         // Root node changes -> re-point to the new DOM element
-        const tagName = getAttrRefComponent(dom) || dom?.tagName.toLowerCase()
-        if (tagName == child.name) {
+        if ((getAttrRefComponent(dom) || dom?.tagName.toLowerCase()) == child.name) {
           self.$el = comp.$el
         }
 
         expr.push(_ => setAttrs(comp.$el, parent))
         // component refs
         self.$refs[node.getAttribute('ref') || tagName] = comp.impl
-
+        
         return { next }
 
       } else {

--- a/packages/nuejs/src/fn.js
+++ b/packages/nuejs/src/fn.js
@@ -1,6 +1,5 @@
 
 import { parseDocument, DomUtils } from 'htmlparser2'
-
 // shared by render.js and compile.js
 
 export const STD = 'a abbr acronym address applet area article aside audio b base basefont bdi bdo big\
@@ -11,7 +10,7 @@ export const STD = 'a abbr acronym address applet area article aside audio b bas
  nav noframes noscript object ol optgroup option output p param path pattern picture polygon polyline\
  pre progress q rect rp rt ruby s samp script section select small source span strike strong style sub\
  summary sup svg switch symbol table tbody td template text textarea textPath tfoot th thead time\
- title tr track tspan tt u ul use var video wbr'.split(' ')
+ title tr track tspan tt u ul use var video wbr !--'.split(' ')
 
 const SVG = 'animate animateMotion animateTransform circle clipPath defs desc ellipse\
  feBlend feColorMatrix feComponentTransfer feComposite feConvolveMatrix feDiffuseLighting\
@@ -78,9 +77,29 @@ function quote(val) {
   return val.endsWith('}') || val.endsWith(']') || 1 * val ? val : `'${val}'`
 }
 
+function addCompNameAttrToSrc(src){
+  let newSrcArray = src.split(' ').map(item => item.replace(/ref-component=w+/, ''));
+
+  return newSrcArray.map(item => {
+    const matches = item.match(/<\s*([^/\s>]+)/);
+    const tag = matches ? matches[1] : null;
+
+    if (tag && !STD.includes(tag)) {
+      
+      // Add the ref-component attribute to the tag
+      const attributeStr = `ref-component="${tag}"`;
+      return item.replace(new RegExp(`<(${tag})`), `<$1 ${attributeStr}`);
+    } else {
+      return item;
+    }
+  }).join(' '); 
+}
+
 export function mkdom(src) {
-  const dom = parseDocument(selfClose(src))
-  walk(dom, (el) => { if (el.type == 'comment') DomUtils.removeElement(el) }) // strip comments
+  const newSrc = addCompNameAttrToSrc(src)
+  const dom = parseDocument(selfClose(newSrc))
+  walk(dom, (el) => {
+    if (el.type == 'comment') DomUtils.removeElement(el) }) // strip comments
   return dom
 }
 

--- a/packages/nuejs/test/render.test.js
+++ b/packages/nuejs/test/render.test.js
@@ -132,7 +132,7 @@ test('Custom tags', () => {
 
     // $attrs
     '<field name="foo" value="bar"/><label @name="field"><input :attr="$attrs"/></label>':
-      '<label><input name="foo" value="bar"></label>',
+      '<label><input ref-component="field" name="foo" value="bar"></label>',
   })
 })
 
@@ -146,7 +146,7 @@ test('Advanced', () => {
     // :attr (:bind works the same on server side)
     '<dd :attr="person"></dd>': '<dd name="Nick" age="10"></dd>',
 
-    '<hey :val/>': '<div is="hey">\n  <script type="application/json">{"val":"1"}</script>\n</div>',
+    '<hey :val/>': '<div ref-component="hey" is="hey">\n  <script type="application/json">{"val":"1"}</script>\n</div>',
 
     '<html><slot for="none"/><b>{ val }</b></html>': '<html><b>1</b></html>',
     '<html><slot for="page"/></html>': '<html><main>Hello</main></html>',


### PR DESCRIPTION
Not sure if this is a fix or a feature.

Referencing components with custom tags using an attribute helps fix the issue of incorrect rendering when uppercase custom tags are present.

example (after parsing src):
`<Ab` --> `<ab ref-component="Ab">`

Fixes #100
