### PR TITLE
fix: accessing child's update function

### DIFF
--- a/packages/nuejs/src/browser/nue.js
+++ b/packages/nuejs/src/browser/nue.js
@@ -249,15 +249,13 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
       // setup refs
 
       // constructor
-      if (Impl) {
-        impl = self.impl = new Impl(ctx)
-
+      if (Impl) impl = self.impl = new Impl(ctx)
+        
         // for
         impl.mountChild = self.mountChild
         impl.$refs = self.$refs
         impl.update = update
-      }
-
+      
       walk(root)
 
       wrap.replaceWith(root)


### PR DESCRIPTION
Add `update` function to `impl` property even if the script tag is empty. 

Fixes #103 