### PR TITLE
fix: fail to build static files on windows

### DIFF
--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -2,6 +2,7 @@
 
 import { log, colors } from './util.js'
 import esMain from 'es-main'
+import { sep } from 'node:path'
 
 // [-npe] --> [-n, -p, -e]
 export function expandArgs(args) {
@@ -25,7 +26,7 @@ export function getArgs(argv) {
   expandArgs(argv.slice(1)).forEach((arg, i) => {
 
     // skip
-    if (arg.endsWith('/cli.js') || arg.endsWith('/nue') || arg == '--') {
+    if (arg.endsWith(sep + 'cli.js') || arg.endsWith('/nue') || arg == '--') {
 
     // test suite
     } else if (arg.endsWith('.test.js')) {


### PR DESCRIPTION
fix #179 

windows file separator is **\\\\**
POSIX  file separator is **/**
[https://nodejs.org/api/path.html#pathsep](https://nodejs.org/api/path.html#pathsep)