### PR TITLE
Fix esbuild is actually not working, even if it is installed in a random nue project

### DIFF
--- a/packages/nuekit/src/builder.js
+++ b/packages/nuekit/src/builder.js
@@ -7,8 +7,9 @@ import { resolve } from 'import-meta-resolve'
 
 
 export async function getBuilder(is_esbuild) {
+  const actual_cwd = process.env.ACTUAL_CWD || process.cwd()
   try {
-    return is_esbuild ? await import(await resolve('esbuild', `file://${process.cwd()}/`)) : Bun
+    return is_esbuild ? await import(resolve('esbuild', `file://${actual_cwd}/`)) : Bun
   } catch {
     throw 'Bundler not found. Please use Bun or install esbuild'
   }

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -12,9 +12,7 @@ export async function init({ dist, is_dev, esbuild, force }) {
   // directories
   const cwd = process.cwd()
   const srcdir = getSourceDir()
-  const fromdir = join(srcdir, 'browser')
   const outdir = join(cwd, dist, '@nue')
-  const minify = !is_dev
 
 
   // has all latest?
@@ -30,8 +28,21 @@ export async function init({ dist, is_dev, esbuild, force }) {
     await fs.writeFile(latest, '')
   }
 
-  // chdir hack (Bun does not support absWorkingDir)
-  process.chdir(srcdir)
+  try {
+    // chdir hack (Bun does not support absWorkingDir)
+    process.chdir(srcdir)
+
+    await initUnderChdir({ dist, is_dev, esbuild, cwd, srcdir, outdir })
+  } finally {
+    // recover
+    process.chdir(cwd)
+  }
+}
+
+async function initUnderChdir({ dist, is_dev, esbuild, cwd, srcdir, outdir }) {
+
+  const fromdir = join(srcdir, 'browser')
+  const minify = !is_dev
 
   // simple function to wtite dot
   function dot() { process.stdout.write('•') }
@@ -87,8 +98,6 @@ export async function init({ dist, is_dev, esbuild, force }) {
 
   // favicon
   await copy('favicon.ico', join(cwd, dist))
-
-  process.chdir(cwd)
 
   // new line
   console.log('')

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -31,10 +31,12 @@ export async function init({ dist, is_dev, esbuild, force }) {
   try {
     // chdir hack (Bun does not support absWorkingDir)
     process.chdir(srcdir)
+    process.env.ACTUAL_CWD = cwd
 
     await initUnderChdir({ dist, is_dev, esbuild, cwd, srcdir, outdir })
   } finally {
     // recover
+    process.env.ACTUAL_CWD = ''
     process.chdir(cwd)
   }
 }

--- a/packages/nuekit/src/nuefs.js
+++ b/packages/nuekit/src/nuefs.js
@@ -16,8 +16,8 @@ import { join, parse, sep } from 'node:path'
 let last = {}
 
 
-export async function fswatch(dir, onfile, onremove) {
-  watch(dir, { recursive: true }, async function(e, path) {
+export function fswatch(dir, onfile, onremove) {
+  return watch(dir, { recursive: true }, async function(e, path) {
     try {
       const file = parse(path)
 

--- a/packages/nuekit/test/nuekit.test.js
+++ b/packages/nuekit/test/nuekit.test.js
@@ -52,7 +52,7 @@ function createFront(title, pubDate) {
 test('defaults', async () => {
   const site = await getSite()
   expect(site.is_empty).toBe(true)
-  expect(site.dist).toBe('_test/.dist/dev')
+  expect(site.dist).toMatchPath('_test/.dist/dev')
   expect(site.port).toBe(8080)
   expect(site.globals).toEqual([])
 })
@@ -71,7 +71,7 @@ test('site.yaml', async () => {
   const site = await getSite()
 
   expect(site.globals).toEqual(['global'])
-  expect(site.dist).toBe('_test/.mydist')
+  expect(site.dist).toMatchPath('_test/.mydist')
   expect(site.port).toBe(1500)
 
   // teardown
@@ -83,7 +83,7 @@ test('environment', async () => {
   await write(env, 'dist: .alt')
   const site = await createSite({ root, env })
 
-  expect(site.dist).toBe('_test/.alt')
+  expect(site.dist).toMatchPath('_test/.alt')
   expect(site.port).toBe(8080)
 })
 

--- a/packages/nuekit/test/nuekit.test.js
+++ b/packages/nuekit/test/nuekit.test.js
@@ -320,8 +320,11 @@ test('the project was started for the first time', async () => {
   await write('home.css')
   await write('index.md')
 
-  await kit.serve()
-  const html = await readDist(kit.dist, 'index.html')
-  expect(html).toInclude('hotreload.js')
-  process.exit()
+  const terminate = await kit.serve()
+  try {
+    const html = await readDist(kit.dist, 'index.html')
+    expect(html).toInclude('hotreload.js')
+  } finally {
+    terminate()
+  }
 })


### PR DESCRIPTION
This PR is based on PR #254 , and supposed to be merged after #254 is merged first.

Background:
I'm a Node user when I'm using my older MacOS. (Seems Bun is not supported in older MacOS, right?)
So I have to use Node + esbuild with nuekit.

The Bug:
Esbuild is actually not working, even if it is installed in a random nue-app.

Reason:
The chdir hack changes the actual cwd to nuekit srcdir, so getBundler is resolving esbuild from the the nuekit srcdir instead of the target nue-app dir.

Steps to reproduce:

```sh
# ensure nue srcdir is clean
# -- esbuild is not installed, as it is not declared in the dependencies
cd nuejs/nue
git checkout -- package.json pnpm-lock.yaml
rm package-lock.json yarn.lock
rm -rf node_modules

# linking to local nue srcdir
rm $(which nue) && (cd packages/nuekit && npm i && npm link) && which nue

# try to run nuekit
alias nu='node $(which nue)'
cd my_nue_app
npm i -D esbuild
rm -rf .dist && nu build && ls -la .dist/dev/@nue
```

```plain
# Actual Output
...
✓ Initialize .dist/dev: Bundler not found. Please use Bun or install esbuild
drwxr-xr-x  13 fritx  staff    416  4  7 16:36 .
drwxr-xr-x  11 fritx  staff    352  4  7 16:36 ..
-rw-r--r--   1 fritx  staff      0  4  7 16:36 .043
```

```plain
# Expected output
✓ Initialize .dist/dev: ••••••••••
...
drwxr-xr-x  13 fritx  staff    416  4  7 16:36 .
drwxr-xr-x  11 fritx  staff    352  4  7 16:36 ..
-rw-r--r--   1 fritx  staff      0  4  7 16:36 .043
-rw-r--r--  1 fritx  staff   1741  4  7 16:36 app-router.js
-rw-r--r--  1 fritx  staff  65144  4  7 16:36 diffdom.js
-rw-r--r--  1 fritx  staff   1199  4  7 16:36 error.css
-rw-r--r--  1 fritx  staff    966  4  7 16:36 error.js
-rw-r--r--  1 fritx  staff   2316  4  7 16:36 glow.css
-rw-r--r--  1 fritx  staff   2829  4  7 16:36 hotreload.js
-rw-r--r--  1 fritx  staff   1324  4  7 16:36 mount.js
-rw-r--r--  1 fritx  staff  10853  4  7 16:36 nue.js
-rw-r--r--  1 fritx  staff    660  4  7 16:36 nuemark.js
-rw-r--r--  1 fritx  staff   3346  4  7 16:36 page-router.js
```