### PR TITLE
chore(cli): make executable filtering more robust

### DIFF
--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -21,7 +21,7 @@ export function expandArgs(args) {
 export function getArgs(argv) {
   const commands = ['serve', 'build', 'stats']
   const args = { paths: [], root: '.' }
-  const checkExecutable = new RegExp(sep + 'nue(\\.(cmd|ps1|bunx|exe))?$')
+  const checkExecutable = /[\\\/]nue(\.(cmd|ps1|bunx|exe))?$/
   let opt
 
   expandArgs(argv.slice(1)).forEach((arg, i) => {

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -21,12 +21,12 @@ export function expandArgs(args) {
 export function getArgs(argv) {
   const commands = ['serve', 'build', 'stats']
   const args = { paths: [], root: '.' }
+  const checkExecutable = new RegExp(sep + 'nue(\\.(cmd|ps1|bunx|exe))?$')
   let opt
 
   expandArgs(argv.slice(1)).forEach((arg, i) => {
-
     // skip
-    if (arg.endsWith(sep + 'cli.js') || arg.endsWith(sep + 'nue') || arg.endsWith(sep + 'nue.cmd') || arg.endsWith(sep + 'nue.ps1') || arg == '--') {
+    if (arg.endsWith(sep + 'cli.js') || checkExecutable.test(arg) || arg == '--') {
 
     // test suite
     } else if (arg.endsWith('.test.js')) {

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -26,7 +26,7 @@ export function getArgs(argv) {
   expandArgs(argv.slice(1)).forEach((arg, i) => {
 
     // skip
-    if (arg.endsWith(sep + 'cli.js') || arg.endsWith('/nue') || arg == '--') {
+    if (arg.endsWith(sep + 'cli.js') || arg.endsWith(sep + 'nue') || arg.endsWith(sep + 'nue.cmd') || arg.endsWith(sep + 'nue.ps1') || arg == '--') {
 
     // test suite
     } else if (arg.endsWith('.test.js')) {


### PR DESCRIPTION
Related:
- #239
- https://github.com/nuejs/nue/issues/253#issuecomment-2081230488

---

See `.bin` folder on Windows with `npm` and `bun` respectively
![image](https://github.com/nuejs/nue/assets/44443899/5b974b86-bca5-4aef-ac93-e35e0aa39d0b)  ![image](https://github.com/nuejs/nue/assets/44443899/5bbd0a55-0675-4d3b-a1d0-8559495c29d0)

and on Linux with both `npm` and `bun`:
![image](https://github.com/nuejs/nue/assets/44443899/71143ecf-f0f7-4405-aeac-7cdf1d068819)

---

Close #253