### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,25 @@
+---
+name: 🐞 Bug Report
+about: Create a bug report to help us improve Nue
+labels: bug
+---
+
+<!-- Please search to see if an issue or discussion already exists for the bug you encountered -->
+
+### Describe the Bug
+<!-- Describe current and expected behavior -->
+
+### Environment
+<!--
+Example:
+- OS: Windows X / Mac Y / Linux Z
+- Package Manager: bun -v / npm -v
+- JS Runtime: bun -v / node -v
+- Nuekit Version: nue -v (if applicable)
+-->
+
+### Minimal Reproduction
+<!-- Please provide a minimal reproduction (e.g. GitHub repo, code snippets, ...) or simple steps to reproduce the bug -->
+
+### Logs & Additional Context
+<!-- Add additional information like logs or other related information -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/nuejs/nue/discussions
+    about: Use discussions if you have an idea for improvement and asking questions

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: 💡 Feature Request or Improvement
+about: Suggest an idea or improvement
+labels: new feature, improvement
+---
+
+### Is your feature request or improvement related to a problem?
+<!-- Describe what the problem is -->
+
+### Solution you'd like
+<!-- A clear and concise description of what you want to happen -->
+
+### Alternatives you've considered
+<!-- Alternative solutions or features you have thought of -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request or improvement here -->


### PR DESCRIPTION
See about this as example here: https://github.com/nobkd/test-issue-templates/issues/new/choose

Allows choosing templates when making a bug report or feature request

Just an idea to give users a rough guideline.

Feel free to improve or reject this concept :)
