### PR TITLE
chore: ignore coverage directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .idea
 .vscode
 _test
+coverage


### PR DESCRIPTION
When running the `jest` test command from GitHub actions, a `coverage` directory is created.
Command: `node --experimental-vm-modules node_modules/jest/bin/jest --runInBand --coverage`

This should not accidentally get pushed.
