### PR TITLE
fix: zero attr

### DIFF
--- a/packages/nuejs/src/render.js
+++ b/packages/nuejs/src/render.js
@@ -56,7 +56,7 @@ function toString(val) {
 
 function setAttribute(key, attribs, data) {
   let val = attribs[key]
-  if (!val) return
+  if (val === null || val === undefined) return
 
   // TODO: check all non-strings here
   if (val.constructor === Object) return

--- a/packages/nuejs/test/render.test.js
+++ b/packages/nuejs/test/render.test.js
@@ -101,14 +101,14 @@ test('Loops', () => {
     '<p :for="[key, value, i] in Object.entries(person)">{ i }: { key } = { value }</p>':
       '<p>0: name = Nick</p><p>1: email = nick@acme.org</p><p>2: age = 10</p>',
 
-    '<p :for="({ name }, i) in items">{ i }. { name }</p>' : '<p>0. John</p><p>1. Alice</p>',
+    '<p :for="({ name }, i) in items">{ i }. { name }</p>': '<p>0. John</p><p>1. Alice</p>',
 
     // loop custom tag
-    '<show :for="el in items" :value="el.name"/> <b @name="show">{ value }</b>' :
+    '<show :for="el in items" :value="el.name"/> <b @name="show">{ value }</b>':
       '<b>John</b><b>Alice</b>',
 
     // loop slots
-    '<thing :for="el in items" :bind="el"><b>{ el.age }</b></thing><u @name="thing">{name}: <slot/></u>' :
+    '<thing :for="el in items" :bind="el"><b>{ el.age }</b></thing><u @name="thing">{name}: <slot/></u>':
       '<u>John: <b>22</b></u><u>Alice: <b>33</b></u>',
 
     // successive loops
@@ -116,7 +116,7 @@ test('Loops', () => {
       '<div><p>-1</p><p>0</p><p>1</p><a>-1</a><a>0</a><a>1</a></div>',
 
   }, {
-    items: [ { name: 'John', age: 22 }, { name: 'Alice', age: 33 }],
+    items: [{ name: 'John', age: 22 }, { name: 'Alice', age: 33 }],
     person: { name: 'Nick', email: 'nick@acme.org', age: 10 },
     nums: [-1, 0, 1],
   })
@@ -144,7 +144,7 @@ test('Advanced', () => {
   runTests({
 
     // :attr (:bind works the same on server side)
-    '<dd :attr="person"></dd>': '<dd name="Nick" age="10"></dd>',
+    '<dd :attr="person"></dd>': '<dd name="Nick" age="0"></dd>',
 
     '<hey :val/>': '<div is="hey">\n  <script type="application/json">{"val":"1"}</script>\n</div>',
 
@@ -156,10 +156,10 @@ test('Advanced', () => {
       '<div><h3>Parent</h3><p></p><p>Nick</p></div>',
 
   }, {
-    person: { name: 'Nick', age: 10 },
+    person: { name: 'Nick', age: 0 },
     page: '<main>Hello</main>',
     nums: [1, 2],
-    val: 1
+    val: 1,
   })
 
 })
@@ -232,7 +232,7 @@ const IF_SIBLING = `
 `
 
 test('If sibling', () => {
-  const els = [{ label: 'First'}]
+  const els = [{ label: 'First' }]
   const html = render(IF_SIBLING, { els })
   expect(html).toInclude('First')
 })

--- a/packages/nuejs/test/render.test.js
+++ b/packages/nuejs/test/render.test.js
@@ -115,10 +115,12 @@ test('Loops', () => {
     '<div><p :for="x in nums">{ x }</p><a :for="y in nums">{ y }</a></div>':
       '<div><p>-1</p><p>0</p><p>1</p><a>-1</a><a>0</a><a>1</a></div>',
 
+    '<i :for="el in falsy">{el}</i>': '<i></i><i>false</i><i>0</i><i>NaN</i><i></i><i></i>'
   }, {
     items: [{ name: 'John', age: 22 }, { name: 'Alice', age: 33 }],
     person: { name: 'Nick', email: 'nick@acme.org', age: 10 },
     nums: [-1, 0, 1],
+    falsy: ['', false, 0, NaN, null, undefined],
   })
 })
 


### PR DESCRIPTION
closes #248 with https://github.com/nuejs/nue/commit/b94f03b57edb2b488ecf9cca402505a00578b84d

You can see this example errors, if not for the change in `render.js`. Just undo that change and run `bun test` to see sth like this:

<details>
<summary>See error log</summary>

```js
41 |             ret += `${str.substring(lastIdx, i)}&#x${getCodePoint(str, i).toString(16)};`;
42 |             // Increase by 1 if we have a surrogate pair
43 |             lastIdx = xmlReplacer.lastIndex += Number((char & 0xfc00) === 0xd800);
44 |         }
45 |     }
46 |     return ret + str.substr(lastIdx);
                      ^
TypeError: str.substr is not a function. (In 'str.substr(lastIdx)', 'str.substr' is undefined)
      at encodeXML (/home/nobkd/<pth>/nue/node_modules/entities/lib/esm/escape.js:46:18)
      at /home/nobkd/<pth>/nue/node_modules/dom-serializer/lib/esm/index.js:49:27
      at map (:1:21)
      at formatAttributes (/home/nobkd/<pth>/nue/node_modules/dom-serializer/lib/esm/index.js:38:12)
      at renderTag (/home/nobkd/<pth>/nue/node_modules/dom-serializer/lib/esm/index.js:142:21)
      at render (/home/nobkd/<pth>/nue/node_modules/dom-serializer/lib/esm/index.js:89:19)
      at render (/home/nobkd/<pth>/nue/node_modules/dom-serializer/lib/esm/index.js:89:19)
      at render (/home/nobkd/<pth>/nue/packages/nuejs/src/render.js:364:23)
      at runTests (/home/nobkd/<pth>/nue/packages/nuejs/test/render.test.js:8:18)
      at /home/nobkd/<pth>/nue/packages/nuejs/test/render.test.js:146:3
```

</details>

---

test `falsy` values with https://github.com/nuejs/nue/commit/b918eb2d25a0908ad4716d99bfe100eee903dde4 (test for something like #193 fixed by https://github.com/nuejs/nue/commit/a3b29f5587314fb2932afb23859af837aadcb680)

