### PR TITLE
Render components inside of buttons

### DIFF
--- a/packages/nuemark/src/tags.js
+++ b/packages/nuemark/src/tags.js
@@ -28,7 +28,7 @@ export const tags = {
   button(data, opts) {
     const { attr, href="#", content=[] } = data
     const label = parseInline(data.label || data._ || content[0] || '')
-    return elem('a', { ...attr, href, role: 'button' }, label || _)
+    return elem('a', { ...attr, href, role: 'button' }, content[0] ? nuemarkdown(content[0]) : label || _)
   },
 
   icon({ _, icon_base='/img', alt }) {

--- a/packages/nuemark/test/nuemark.test.js
+++ b/packages/nuemark/test/nuemark.test.js
@@ -233,6 +233,11 @@ test('[button]', () => {
   expect(html).toInclude('<em>Hey</em>')
 })
 
+test('[button] with svg', () => {
+  const html = tags.button({ content: '[mysvg]\n' })
+  expect(html).toInclude('<a href="#" role="button"><div is="mysvg"></div></a>')
+})
+
 
 // page rendering
 test('render sections', () => {

--- a/packages/nuemark/test/nuemark.test.js
+++ b/packages/nuemark/test/nuemark.test.js
@@ -234,7 +234,7 @@ test('[button]', () => {
 })
 
 test('[button] with svg', () => {
-  const html = tags.button({ content: '[mysvg]\n' })
+  const html = tags.button({ content: [ '[mysvg]\n' ] })
   expect(html).toInclude('<a href="#" role="button"><div is="mysvg"></div></a>')
 })
 


### PR DESCRIPTION
As the title says this simple change will allow you to put components from layout.html or another .nue file inside of buttons inside of your markdown. Fixes #277