### PR TITLE
fix: cli create

### DIFF
--- a/packages/nuekit/src/create.js
+++ b/packages/nuekit/src/create.js
@@ -1,43 +1,43 @@
-
-import { createKit } from './nuekit.js'
-import { finished } from 'node:stream/promises'
-import { createWriteStream } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { promises as fs } from 'node:fs'
-import { Readable } from 'node:stream'
 
+import { createKit } from './nuekit.js'
 
 async function serve() {
   const nue = await createKit({ root: '.' })
-  await nue.serve()
+  const terminate = await nue.serve()
 
   // open welcome page
-  execSync('open http://localhost:8083/welcome/')
+  const open = process.platform == 'darwin' ? 'open' : process.platform == 'win32' ? 'start' : 'xdg-open'
+  try {
+    execSync(`${open} http://localhost:${nue.port}/welcome/`)
+  } catch {}
+  return terminate
 }
 
-export async function create({ name='simple-blog' }) {
+export async function create({ name = 'simple-blog' }) {
 
   // read files
-  const files = await fs.readdir('.')
+  const files = (await fs.readdir('.')).filter(f => !f.startsWith('.'))
 
   // already created -> serve
   if (files.includes('site.yaml')) return serve()
 
   // currently only simple-blog is available
-  if (name != 'simple-blog') return console.error('Template does not exist', name)
+  if (name != 'simple-blog') return console.error('Template does not exist:', name)
 
   // must be empty directory
-  if (files[1] || files[0] != '.DS_Store') {
-    return console.error('Please create the appplication to an empty directory')
-  }
+  if (files.length) return console.error('Please create the template to an empty directory')
 
-  // download zip
-  const zip = await fetch(`https://${ name }.nuejs.org/${name}.zip`)
-  await Bun.write('source.zip', zip)
+  // download archive
+  const archive_name = 'source.tar.gz'
+  const archive = await fetch(`https://${name}.nuejs.org/${name}.tar.gz`)
+  await fs.writeFile(archive_name, await archive.arrayBuffer())
 
-  // unzip
-  await execSync('unzip source.zip')
+  // unzip and remove archive
+  execSync(`tar -xf ${archive_name}`)
+  await fs.rm(archive_name)
 
   // serve
-  await serve()
+  return await serve()
 }

--- a/packages/nuekit/src/nuekit.js
+++ b/packages/nuekit/src/nuekit.js
@@ -354,7 +354,7 @@ export async function createKit(args) {
     gen, getPageData, renderMPA, renderSPA,
 
     // public API
-    build, serve, stats, dist,
+    build, serve, stats, dist, port,
   }
 
 }

--- a/packages/nuekit/test/misc.test.js
+++ b/packages/nuekit/test/misc.test.js
@@ -50,11 +50,10 @@ test('path parts', () => {
 })
 
 
-test.only('create', async () => {
+test('create', async () => {
   await fs.mkdir('simple-blog', { recursive: true })
   await process.chdir('simple-blog')
 
-  const body = await create({ name: 'simple-blog' })
-
-
+  const terminate = await create({ name: 'simple-blog' })
+  terminate()
 })


### PR DESCRIPTION
Changes:
- use tarball archive (in my case a gzip compressed tarball), as `tar` CLI tool is available by default on most platforms
- support opening link on more platforms (fail silently, to keep server running, and isn't problematic if missing)
- get port from nue server
- ignore dot-files and -dirs on empty check. (helps e.g. with empty git repos)
- use node compatible file writing

Currently fails, because `https://simple-blog.nuejs.org/simple-blog.tar.gz` obviously does not exist.

> [!note]
> Feel free to reject, just had fun checking how this could work on more platforms

Future ideas:
- use directory from `-r` option, extract archive there and use it for root of serve
- maybe fix opening from wsl (I at least think, it does not work, not actually tested)
