### PR TITLE
fix: create cli

### DIFF
--- a/packages/nuejs.org/docs/command-line-interface.md
+++ b/packages/nuejs.org/docs/command-line-interface.md
@@ -9,7 +9,7 @@ The command line interface documents itself with a `--help` option:
 nue --help
 ```
 
-This returns following output:
+This returns the following output:
 
 ```md
 Usage
@@ -20,7 +20,8 @@ Usage
 Commands
   serve    Start development server (default command)
   build    Build the site under <root_dir>
-  stats    Show site statistics (beta)
+  stats    Show site statistics
+  create   Use a project starter template
 
 Options
   -r or --root          Source directory. Default "." (current working dir)
@@ -29,7 +30,7 @@ Options
   -s or --stats         Show site statistics after current command
   -I or --init          Force clear and initialize output directory
   -n or --dry-run       Show what would be built. Does not create outputs
-  -b or --esbuild       Use esbuild. `npm install -g esbuild` required
+  -b or --esbuild       Use esbuild as bundler. Please install it manually
 
 File matches
   Only build files that match the rest of the arguments. For example:
@@ -49,7 +50,7 @@ Examples
   nue build .md .css
 
   # more examples
-  open https://nuejs.org/docs/cli
+  open https://nuejs.org/docs/command-line-interface.html
 
 Less is more
 
@@ -57,9 +58,7 @@ Less is more
  ┃┏┓┫┃┃┃┃━┫
  ┃┃┃┃┗┛┃┃━┫  nuejs.org
  ┗┛┗┻━━┻━━┛
-
 ```
-
 
 ## Examples
 Few more usage examples:

--- a/packages/nuekit/src/cli-help.js
+++ b/packages/nuekit/src/cli-help.js
@@ -10,6 +10,7 @@ Commands
   serve    Start development server (default command)
   build    Build the site under <root_dir>
   stats    Show site statistics
+  create   Use a project starter template
 
 Options
   -r or --root          Source directory. Default "." (current working dir)
@@ -38,12 +39,12 @@ Examples
   nue build .md .css
 
   # more examples
-  ${openUrl} https://nuejs.org/docs/cli
+  ${openUrl} https://nuejs.org/docs/command-line-interface.html
 
 Less is more
 
  ┏━┓┏┓┏┳━━┓
- ┃┏┓┫┃┃┃┃━┫  v${await getVersion()}
+ ┃┏┓┫┃┃┃┃━┫  kit ${await getVersion()}
  ┃┃┃┃┗┛┃┃━┫  nuejs.org
  ┗┛┗┻━━┻━━┛
 `

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -20,7 +20,7 @@ export function expandArgs(args) {
 // TODO: tests
 export function getArgs(argv) {
   const commands = ['serve', 'build', 'stats', 'create']
-  const args = { paths: [], root: '.' }
+  const args = { paths: [], root: null }
   const checkExecutable = /[\\\/]nue(\.(cmd|ps1|bunx|exe))?$/
   let opt
 
@@ -81,10 +81,10 @@ async function printVersion() {
 
 async function runCommand(args) {
   const { createKit } = await import('./nuekit.js')
-  const { cmd='serve', dryrun, push, root } = args
+  const { cmd='serve', dryrun, push, root=null } = args
+  if (!root) args.root = '.'
 
   console.info('')
-
 
   // create nue
   if (cmd == 'create') {
@@ -126,10 +126,6 @@ if (esMain(import.meta)) {
   // version
   } else if (args.version) {
     await printVersion()
-
-  // root is required
-  } else if (!args.root) {
-    console.info('Project root not specified')
 
   // command
   } else if (!args.test) {

--- a/packages/nuekit/src/create.js
+++ b/packages/nuekit/src/create.js
@@ -1,5 +1,6 @@
-import { execSync } from 'node:child_process'
-import { promises as fs } from 'node:fs'
+import { exec, execSync } from 'node:child_process'
+import { promises as fs, existsSync } from 'node:fs'
+import { join } from 'node:path'
 
 import { openUrl } from './util.js'
 import { createKit } from './nuekit.js'
@@ -9,19 +10,12 @@ async function serve(root) {
   const terminate = await nue.serve()
 
   // open welcome page
-  try {
-    execSync(`${openUrl} http://localhost:${nue.port}/welcome/`)
-  } catch {}
+  exec(`${openUrl} http://localhost:${nue.port}/welcome/`)
   return terminate
 }
 
-export async function create({ root = '.', name = 'simple-blog' }) {
-
-  // read files
-  const files = (await fs.readdir(root)).filter(f => !f.startsWith('.'))
-
-  // already created -> serve
-  if (files.includes('site.yaml')) return serve(root)
+export async function create({ root, name = 'simple-blog' }) {
+  if (!root) root = name
 
   // debug mode with: `nue create test`
   const debug = name == 'test'
@@ -30,16 +24,25 @@ export async function create({ root = '.', name = 'simple-blog' }) {
   // currently only simple-blog is available
   if (name != 'simple-blog') return console.error(`Template "${name}" does not exist`)
 
-  // must be empty directory
-  if (files.length) return console.error('Please create the template to an empty directory')
+  if (existsSync(root)) {
+    // read files
+    const files = (await fs.readdir(root)).filter(f => !f.startsWith('.'))
+
+    // already created -> serve
+    if (files.includes('site.yaml')) return serve(root)
+
+    // must be empty directory
+    if (files.length) return console.error('Please create the template to an empty directory')
+
+  } else await fs.mkdir(root, { recursive: true })
 
   // download archive
-  const archive_name = 'source.tar.gz'
+  const archive_name = join(root, `${name}-source.tar.gz`)
   const archive = await fetch(`https://${name}.nuejs.org/${debug ? 'test' : name}.tar.gz`)
   await fs.writeFile(archive_name, Buffer.from(await archive.arrayBuffer()))
 
   // uncompress
-  execSync(`tar -xf ${archive_name} -C ${root}`)
+  execSync(`tar -C ${root} --strip-components 1 -xf ${archive_name}`)
 
   // remove archive
   await fs.rm(archive_name)

--- a/packages/nuekit/src/create.js
+++ b/packages/nuekit/src/create.js
@@ -37,6 +37,7 @@ export async function create({ root, name = 'simple-blog' }) {
   } else await fs.mkdir(root, { recursive: true })
 
   // download archive
+  console.info('Loading template...')
   const archive_name = join(root, `${name}-source.tar.gz`)
   const archive = await fetch(`https://${name}.nuejs.org/${debug ? 'test' : name}.tar.gz`)
   await fs.writeFile(archive_name, Buffer.from(await archive.arrayBuffer()))

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -27,7 +27,17 @@ export async function init({ dist, is_dev, esbuild, force }) {
     await fs.writeFile(latest, '')
   }
 
-  await initDir({ dist, is_dev, esbuild, cwd, srcdir, outdir })
+  try {
+    // chdir hack (Bun does not support absWorkingDir)
+    process.chdir(srcdir)
+    process.env.ACTUAL_CWD = cwd
+
+    await initDir({ dist, is_dev, esbuild, cwd, srcdir, outdir })
+  } finally {
+    // recover
+    process.env.ACTUAL_CWD = ''
+    process.chdir(cwd)
+  }
 }
 
 async function initDir({ dist, is_dev, esbuild, cwd, srcdir, outdir }) {

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -27,17 +27,7 @@ export async function init({ dist, is_dev, esbuild, force }) {
     await fs.writeFile(latest, '')
   }
 
-  try {
-    // chdir hack (Bun does not support absWorkingDir)
-    process.chdir(srcdir)
-    process.env.ACTUAL_CWD = cwd
-
-    await initDir({ dist, is_dev, esbuild, cwd, srcdir, outdir })
-  } finally {
-    // recover
-    process.env.ACTUAL_CWD = ''
-    process.chdir(cwd)
-  }
+  await initDir({ dist, is_dev, esbuild, cwd, srcdir, outdir })
 }
 
 async function initDir({ dist, is_dev, esbuild, cwd, srcdir, outdir }) {
@@ -107,6 +97,6 @@ async function initDir({ dist, is_dev, esbuild, cwd, srcdir, outdir }) {
 
 function resolvePath(npm_path) {
   const [ npm_name, ...parts ] = npm_path.split('/')
-  const module_path = dirname(fileURLToPath(resolve(npm_name, `file://${process.cwd()}/`)))
+  const module_path = dirname(fileURLToPath(resolve(npm_name, import.meta.url)))
   return join(module_path, ...parts)
 }

--- a/packages/nuekit/test/misc.test.js
+++ b/packages/nuekit/test/misc.test.js
@@ -6,6 +6,7 @@ import { create } from '../src/create.js'
 import { getArgs } from '../src/cli.js'
 
 import { toMatchPath } from './match-path.js'
+
 import { promises as fs } from 'node:fs'
 
 expect.extend({ toMatchPath })
@@ -59,6 +60,6 @@ test('path parts', () => {
 
 
 test('create', async () => {
-	const terminate = await create({ root, name: 'simple-blog' })
+	const terminate = await create({ root, name: 'test' })
 	terminate()
 })


### PR DESCRIPTION
fix #313

- replace chdir hack with `import.meta.url`
- fixes some root dir issues with create cli, default dir is starter name
- update cli help page (add NUE **kit** version, cli command, fix link (when www2 content gets on main domain))
- strip compressed directory name on unpacking (https://github.com/nuejs/nue/pull/309#issuecomment-2287860868)
- use `exec` for create link opening to prevent test timeout / not "block" for too long

Tested extracting tar / create command on Linux & Windows

Note: maybe you can fix: https://github.com/nuejs/nue/pull/309#issuecomment-2289093574 for both `test.tar.gz` and `simple-blog.tar.gz`