### PR TITLE
typo fix in installation.md

### DIFF
--- a/packages/nuejs.org/docs/installation.md
+++ b/packages/nuejs.org/docs/installation.md
@@ -59,7 +59,7 @@ Please post an [issue](//github.com/nuejs/nue/issues). Thank you!
 
 
 ## Node setup { #node }
-Istall Nue with `pnpm`, `npm` or `yarn`:
+Install Nue with `pnpm`, `npm` or `yarn`:
 
 ```sh
 pnpm install nuekit --global


### PR DESCRIPTION
Fix typo: replace 'Istall' with 'Install'

![image](https://github.com/user-attachments/assets/3b74b3b8-004d-452d-a047-d49acd19750c)
