### PR TITLE
feat: add port cli option

### DIFF
--- a/packages/nuejs.org/docs/command-line-interface.md
+++ b/packages/nuejs.org/docs/command-line-interface.md
@@ -31,6 +31,7 @@ Options
   -I or --init          Force clear and initialize output directory
   -n or --dry-run       Show what would be built. Does not create outputs
   -b or --esbuild       Use esbuild as bundler. Please install it manually
+  -P or --port          Port to serve the site on
 
 File matches
   Only build files that match the rest of the arguments. For example:

--- a/packages/nuekit/src/cli-help.js
+++ b/packages/nuekit/src/cli-help.js
@@ -20,6 +20,7 @@ Options
   -I or --init          Force clear and initialize output directory
   -n or --dry-run       Show what would be built. Does not create outputs
   -b or --esbuild       Use esbuild as bundler. Please install it manually
+  -P or --port          Port to serve the site on
 
 File matches
   Only build files that match the rest of the arguments. For example:

--- a/packages/nuekit/src/create.js
+++ b/packages/nuekit/src/create.js
@@ -5,8 +5,8 @@ import { join } from 'node:path'
 import { openUrl } from './util.js'
 import { createKit } from './nuekit.js'
 
-async function serve(root, debug) {
-  const nue = await createKit({ root })
+async function serve(root, port, debug) {
+  const nue = await createKit({ root, port })
   const terminate = await nue.serve()
 
   // open welcome page
@@ -14,7 +14,7 @@ async function serve(root, debug) {
   return terminate
 }
 
-export async function create({ root, name = 'simple-blog' }) {
+export async function create({ root, name = 'simple-blog', port }) {
   if (!root) root = name
 
   // debug mode with: `nue create test`
@@ -49,5 +49,5 @@ export async function create({ root, name = 'simple-blog' }) {
   await fs.rm(archive_name)
 
   // serve
-  return await serve(root, debug)
+  return await serve(root, port, debug)
 }

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -78,12 +78,11 @@ export async function createSite(args) {
     libs: site_data.libs || [],
   }
 
-  const {
-    dist: rawDist,
-    port = is_prod ? 8081 : 8080
-  } = site_data
+  const port = args.port ? args.port :
+    site_data.port ? site_data.port :
+      is_prod ? 8081 : 8080
 
-  const dist = joinRootPath(root, rawDist || join('.dist', is_prod ? 'prod' : 'dev'))
+  const dist = joinRootPath(root, site_data.dist || join('.dist', is_prod ? 'prod' : 'dev'))
 
   // flag if .dist is empty
   try {


### PR DESCRIPTION
- fix https://github.com/nuejs/nue/discussions/275#discussioncomment-10332839

port option priority: `cli option` over `site.yaml` over default (`8080`/`8081`)

---

Other changes:
- Renamed `push` option to `deploy`
- comment explaining code for `root`-dir-forwarding for `create` command