### PR TITLE
fix: handle unknown mime

### DIFF
--- a/packages/nuekit/src/browser/view-transitions.js
+++ b/packages/nuekit/src/browser/view-transitions.js
@@ -143,10 +143,12 @@ export function onclick(root, fn) {
     const el = e.target.closest('[href]')
     const path = el?.getAttribute('href')
     const target = el?.getAttribute('target')
+    const pathname = new URL(path).pathname    
 
     // event ignore
     if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ||
       !path || path[0] == '#' || path.includes('//') || path.startsWith('mailto:') ||
+      (pathname.split('/').pop()?.includes('.') && !pathname.endsWith('.html')) ||
       target == '_blank') return
 
     // all good

--- a/packages/nuekit/src/browser/view-transitions.js
+++ b/packages/nuekit/src/browser/view-transitions.js
@@ -143,13 +143,12 @@ export function onclick(root, fn) {
     const el = e.target.closest('[href]')
     const path = el?.getAttribute('href')
     const target = el?.getAttribute('target')
-    const pathname = new URL(path).pathname    
+    const name = path?.split('/')?.pop()?.split(/[#?]/)?.shift()
 
     // event ignore
     if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ||
-      !path || path[0] == '#' || path.includes('//') || path.startsWith('mailto:') ||
-      (pathname.split('/').pop()?.includes('.') && !pathname.endsWith('.html')) ||
-      target == '_blank') return
+        !path || path[0] == '#' || path?.includes('//') || path?.startsWith('mailto:') ||
+        (name?.includes('.') && !name?.endsWith('.html')) || target == '_blank') return
 
     // all good
     if (path != location.pathname) fn(path)

--- a/packages/nuekit/src/nueserver.js
+++ b/packages/nuekit/src/nueserver.js
@@ -41,15 +41,18 @@ export function createServer(root, callback) {
     }
 
     let [ url, _ ] = req.url.split('?')
-    const ext = extname(url).slice(1)
+    let ext = extname(url).slice(1)
 
-    if (!ext) url = join(url, 'index.html')
+    if (!ext) {
+      url = join(url, 'index.html')
+      ext = 'html'
+    }
 
     try {
       const { code, path } = !ext || ext == 'html' ? await callback(url, _) : { path: url }
       if (!path) throw { errno: -2 }
       const buffer = await fs.readFile(join(root, path))
-      res.writeHead(code || 200, { 'content-type': TYPES[ext] || TYPES.html })
+      res.writeHead(code || 200, { 'content-type': TYPES[ext] })
       res.end(buffer)
   
     } catch(e) {


### PR DESCRIPTION
If mime type not in default mime type object, let browser determine how to handle response.

Fix navigation to other file types than HTML (or extensionless (base) route), when using view transitions
