### PR TITLE
fix!: make components case-insensitive

### DIFF
--- a/packages/nuejs/src/browser/nue.js
+++ b/packages/nuejs/src/browser/nue.js
@@ -213,7 +213,10 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
 
   // context
   let impl = {}
-  const CaseInsensitiveObject = { get: function (target, name) { return target[name?.toLowerCase()] } }
+  const CaseInsensitiveObject = {
+    get(target, key) { return target[key?.toLowerCase()] },
+    set(target, key, val) { target[key?.toLowerCase()] = val },
+  }
 
   const self = {
     update,

--- a/packages/nuejs/src/browser/nue.js
+++ b/packages/nuejs/src/browser/nue.js
@@ -213,6 +213,7 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
 
   // context
   let impl = {}
+  const CaseInsensitiveObject = { get: function (target, name) { return target[name?.toLowerCase()] } }
 
   const self = {
     update,
@@ -222,7 +223,7 @@ export default function createApp(component, data={}, deps=[], $parent={}) {
     // root === $el
     get root() { return self.$el },
 
-    $refs: {},
+    $refs: new Proxy({}, CaseInsensitiveObject),
 
     $parent,
 

--- a/packages/nuejs/src/fn.js
+++ b/packages/nuejs/src/fn.js
@@ -35,7 +35,7 @@ export function getComponentName(root) {
   const { attribs } = root
   const name = attribs['@name'] || attribs['data-name'] // || attribs.id
   delete attribs['@name']
-  return name
+  return name?.toLowerCase()
 }
 
 export function selfClose(str) {


### PR DESCRIPTION
This is just some idea I had when reading #100, and it would fix #100, but I'm not sure, if this is a good idea. This just makes components case-insensitive and passes the access to the object through a proxy that makes all key accesses lower-case. This PR solves the problem, because **HTML elements are case-insensitive for the browser by default**, but currently might allow collisions on Component creation...

Well... This is just a proposal to make components case-insensitive in the end...
Okay, I'm really repeating myself.

This was just a quick sketch to outline the idea and might have some obvious flaws, and the code can be changed more, to make this better integrated (and fix some possible issues)...

Feel free to reject and let me know your opinion about this.