### PR TITLE
fix: allow textarea resizing only vertically

### DIFF
--- a/packages/examples/simple-blog/@library/forms.css
+++ b/packages/examples/simple-blog/@library/forms.css
@@ -28,6 +28,7 @@ input, textarea {
 }
 
 textarea {
+  resize: vertical;
   form-sizing: normal;
   min-height: 80px;
 }


### PR DESCRIPTION
prevents resizing text area outside of page creating horizontal overflow