### PR TITLE
chore: async exists

### DIFF
--- a/packages/nuekit/src/create.js
+++ b/packages/nuekit/src/create.js
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process'
-import { promises as fs, existsSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 
 import { openUrl } from './util.js'
@@ -24,7 +24,7 @@ export async function create({ root, name = 'simple-blog', port }) {
   // currently only simple-blog is available
   if (name != 'simple-blog') return console.error(`Template "${name}" does not exist`)
 
-  if (existsSync(root)) {
+  if (await fs.exists(root)) {
     // read files
     const files = (await fs.readdir(root)).filter(f => !f.startsWith('.'))
 

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -2,7 +2,7 @@
 import { compileFile as nueCompile } from 'nuejs-core'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { promises as fs, existsSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
 import { resolve } from 'import-meta-resolve'
 import { buildJS } from './builder.js'
 import { colors, srcdir } from './util.js'
@@ -16,7 +16,7 @@ export async function initNueDir({ dist, is_dev, esbuild, force }) {
   // has all latest?
   const latest = join(outdir, '.beta-2')
 
-  if (force || !existsSync(latest)) {
+  if (force || !await fs.exists(latest)) {
     await fs.rm(outdir, { recursive: true, force: true })
     await fs.mkdir(outdir, { recursive: true })
     await fs.writeFile(latest, '')

--- a/packages/nuekit/src/nuekit.js
+++ b/packages/nuekit/src/nuekit.js
@@ -31,7 +31,7 @@ export async function createKit(args) {
   }
 
 
-  if (!(await fs.exists('site.yaml'))) {
+  if (!await fs.exists('site.yaml')) {
     console.error('No site.yaml found. Please go to project root\n')
     return false
   }

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -11,7 +11,7 @@ import {
 
 import { join, extname, parse as parsePath } from 'node:path'
 import { parse as parseNue } from 'nuejs-core'
-import { promises as fs, existsSync } from 'node:fs'
+import { promises as fs } from 'node:fs'
 import { fswalk } from './nuefs.js'
 import { nuemark } from 'nuemark'
 import yaml from 'js-yaml'
@@ -29,7 +29,7 @@ export async function createSite(args) {
   const cache = {}
 
   // make sure root exists
-  if (!existsSync(root)) throw `Root directory does not exist: ${root}`
+  if (!await fs.exists(root)) throw `Root directory does not exist: ${root}`
 
   /*
     Bun.file()::text() has equal performance
@@ -76,7 +76,7 @@ export async function createSite(args) {
 
 
   // flag if .dist is empty
-  if (!existsSync(dist)) self.is_empty = true
+  if (!await fs.exists(dist)) self.is_empty = true
 
   async function write(content, dir, filename) {
     const todir = join(dist, dir)
@@ -232,7 +232,7 @@ export async function createSite(args) {
     const arr = []
 
     // make sure dir exists
-    if (!existsSync(join(root, dir))) {
+    if (!await fs.exists(join(root, dir))) {
       console.error(`content collection: "${dir}" does not exist`)
       return arr
     }
@@ -323,7 +323,7 @@ export async function createSite(args) {
 
     for (const [dir, name, ext] of try_files) {
       const src = join(dir, `${name}.${ext}`)
-      if (existsSync(join(root, src)))
+      if (await fs.exists(join(root, src)))
         return { src, path: join(dir, `${name}.html`), name }
     }
   }


### PR DESCRIPTION
Follow up to https://github.com/nuejs/nue/commit/6b0181e12319767f36cf0e876784bec3fab0abef

> [!Note]
> Updates to `dev` branch

You seem to have broken some tests. (Not so sure about the `create` one though)

Should I change the test-run workflow to include `dev` branch, so you see that something lets the tests fail, sooner?