### PR TITLE
fix: make version available

### DIFF
--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -98,10 +98,10 @@ async function runCommand(args) {
     return await create({ root, name: args.paths[0], port })
   }
 
+  args.nuekit_version = await printVersion()
+
   const nue = await createKit(args)
   if (!nue) return
-
-  args.nuekit_version = await printVersion()
 
   // deployer (private repo)
   const { deploy: deployer } = deploy ? await import('nue-deployer') : {}


### PR DESCRIPTION
Makes nuekit version available with variable `nuekit_version`

fixes #356

Also fixes the `generator` for the `<head>` in production, that got broken somewhere :shrug: