### PR TITLE
feat!: escape {} templates

### DIFF
--- a/packages/nuejs/src/expr.js
+++ b/packages/nuejs/src/expr.js
@@ -1,8 +1,7 @@
 
 const VARIABLE = /(^|[\-\+\*\/\!\s\(\[]+)([\$a-z_]\w*)\b/g
 const STRING = /('[^']+'|"[^"]+")/
-const EXPR = /\{([^{}]+)\}/g
-
+const EXPR = /([^\\]|^)\{((?:\\{|\\}|[^{}])*[^\\])\}/g
 
 // https://github.com/vuejs/core/blob/main/packages/shared/src/globalsWhitelist.ts
 const RESERVED = `
@@ -31,7 +30,11 @@ export function setContext(expr) {
 export function parseExpr(str, is_style) {
   const ret = []
 
-  str.split(EXPR).map((str, i) => {
+  const strs = []
+  str.split(EXPR).forEach((val, i) => strs.push(i % 3 == 1 ? strs.pop() + val : val))
+
+  strs.map((str, i) => {
+    str = str.replace(/\\([{}])/g, '$1')
 
     // normal string
     if (i % 2 == 0) {

--- a/packages/nuejs/src/expr.js
+++ b/packages/nuejs/src/expr.js
@@ -1,7 +1,7 @@
 
 const VARIABLE = /(^|[\-\+\*\/\!\s\(\[]+)([\$a-z_]\w*)\b/g
 const STRING = /('[^']+'|"[^"]+")/
-const EXPR = /([^\\]|^)\{((?:\\{|\\}|[^{}])*[^\\])\}/g
+const EXPR = /([^\\]|^)\{([^{}]*[^\\{}])\}/g
 
 // https://github.com/vuejs/core/blob/main/packages/shared/src/globalsWhitelist.ts
 const RESERVED = `

--- a/packages/nuejs/test/parse.test.js
+++ b/packages/nuejs/test/parse.test.js
@@ -47,12 +47,6 @@ test('Expressions', () => {
   runTests(parseExpr, {
     'Hey { name }': [ "'Hey '", '_.name' ],
     'Hey {{ name }': [ "'Hey {'", '_.name' ],
-    'Hey {}': [ "'Hey {}'" ],
-    'Hey {\\}': [ "'Hey {}'" ],
-    'Hey \\{\\}': [ "'Hey {}'" ],
-    'Hey {\\{\\}}': [ "'Hey '", '{}' ],
-    'Hey {{\\}}': [ "'Hey {'", '}' ],
-    'Hey {[1,2,3,4,5].map(i => \\{return i*i\\})}': [ "'Hey '", '[1,2,3,4,5].map(i => {return i*i})' ],
     "Hey, I'm { name }": [ '"Hey, I\'m "', '_.name' ],
     'foo { alarm } is-alert': [ "'foo '", '_.alarm', "' is-alert'" ],
     'is-cool { danger: hasError }': [ "'is-cool '", "_.hasError && 'danger '" ],
@@ -61,7 +55,15 @@ test('Expressions', () => {
       "_.isActive && 'is-active '",
       "' is-cool '",
       "_.hasError && 'danger '"
-    ]
+    ],
+    'Hey {}': [ "'Hey {}'" ],
+    'Hey {\\}': [ "'Hey {}'" ],
+    'Hey {\\}}': [ "'Hey {}}'" ],
+    'Hey \\{\\}': [ "'Hey {}'" ],
+    'Hey {\\{\\}}': [ "'Hey {{}}'" ],
+    'Hey {{\\}}': [ "'Hey {{}}'" ],
+    '^\\d\\{4,5}$': [ "'^\\d{4,5}$'" ],
+    '\\\\{sth}': [ "'\\{sth}'" ],
   })
 })
 

--- a/packages/nuejs/test/parse.test.js
+++ b/packages/nuejs/test/parse.test.js
@@ -46,6 +46,13 @@ test('Expressions', () => {
 
   runTests(parseExpr, {
     'Hey { name }': [ "'Hey '", '_.name' ],
+    'Hey {{ name }': [ "'Hey {'", '_.name' ],
+    'Hey {}': [ "'Hey {}'" ],
+    'Hey {\\}': [ "'Hey {}'" ],
+    'Hey \\{\\}': [ "'Hey {}'" ],
+    'Hey {\\{\\}}': [ "'Hey '", '{}' ],
+    'Hey {{\\}}': [ "'Hey {'", '}' ],
+    'Hey {[1,2,3,4,5].map(i => \\{return i*i\\})}': [ "'Hey '", '[1,2,3,4,5].map(i => {return i*i})' ],
     "Hey, I'm { name }": [ '"Hey, I\'m "', '_.name' ],
     'foo { alarm } is-alert': [ "'foo '", '_.alarm', "' is-alert'" ],
     'is-cool { danger: hasError }': [ "'is-cool '", "_.hasError && 'danger '" ],


### PR DESCRIPTION
fix #252 

You can now use the following in html:
- `^\d\{4,5}$` -> `^\d{4,5}$`
- `^\d\{4,5\}$` -> `^\d{4,5}$`
- `^\d{4,5\}$` -> `^\d{4,5}$`

E.g. `<input type="text" name="captcha" value="" placeholder="" required pattern="^\d\{4,5\}$" />`
For `\{` as result double escaping is needed now: `\\{` -> `\{` (html syntax) (would be `\\\\{` -> `\\{` in js strings)

You still cannot do something like:

- `{'\{fails\}'}` -> `{'{fails}'}` (does not result in maybe expected: `'{fails}'`)


PS: I'm not sure, if this should be merged, as it adds a bit of complexity to the regexp and has to recombine some strings to get back the expected format...

PPS: This *might* be breaking code for some people, but not really. It has parity with templates from before, but because of the new `\{` / `\}` escaping, some (very small amount of) code has to change a little bit.