### PR TITLE
Revert "fix: space around block md ext"

### DIFF
--- a/packages/nuemark/src/parse.js
+++ b/packages/nuemark/src/parse.js
@@ -170,10 +170,10 @@ export function parseBlocks(lines) {
     // code line
     if (fenced) return fenced.content.push(line)
 
+
     // component
-    const trimmed = line.trim()
-    if (!comp && trimmed[0] == '[' && trimmed.slice(-1) == ']' && !line.includes('][')) {
-      comp = parseComponent(trimmed.slice(1, -1))
+    if (line[0] == '[' && line.slice(-1) == ']' && !line.includes('][')) {
+      comp = parseComponent(line.slice(1, -1))
       blocks.push(comp)
       md = null
 

--- a/packages/nuemark/test/nuemark.test.js
+++ b/packages/nuemark/test/nuemark.test.js
@@ -119,12 +119,12 @@ test('[tabs] key and wrapper', () => {
 
 
 const NESTED_TABS = `
- [tabs "Foo | Bar"]
+[tabs "Foo | Bar"]
   First
   ---
   Second
 
-  [tabs "Baz | Bruh" key="inner"]\t
+  [tabs "Baz | Bruh" key="inner"]
     Inner 1
     ---
     Inner 2


### PR DESCRIPTION
Reverts #363

this part `!comp &&` (I think), breaks code like the following:


```md
[! img/controls.svg width=50px]

[! img/controls.svg width=50px]

[! img/controls.svg width=50px]
```

resulting in

```html
<figure><img loading="lazy" width="50px" src="img/controls.svg"></figure>
<p>[! img/controls.svg width=50px]</p>
<figure><img loading="lazy" width="50px" src="img/controls.svg"></figure>
```

If the next md extension was nested, or the next line was no md extension, there would be no problem.

---

I will check, if I find a solution, to prevent this issue after all, but for now, I leave this reverting PR open