### PR TITLE
fix: block ext spacing

### DIFF
--- a/packages/nuemark/src/parse.js
+++ b/packages/nuemark/src/parse.js
@@ -170,15 +170,9 @@ export function parseBlocks(lines) {
     // code line
     if (fenced) return fenced.content.push(line)
 
-    // component
     const trimmed = line.trim()
-    if (!comp && trimmed[0] == '[' && trimmed.slice(-1) == ']' && !line.includes('][')) {
-      comp = parseComponent(trimmed.slice(1, -1))
-      blocks.push(comp)
-      md = null
-
     // component args
-    } else if (comp) {
+    if (comp) {
       const next = getNext(lines, i)
       const indent = getIndent(next)
 
@@ -190,6 +184,12 @@ export function parseBlocks(lines) {
 
       if (!line.trimStart()) comp.body?.push(line)
       else if (!getIndent(line)) comp = null
+   
+    // component
+    } else if (trimmed[0] == '[' && trimmed.slice(-1) == ']' && !line.includes('][')) {
+      comp = parseComponent(trimmed.slice(1, -1))
+      blocks.push(comp)
+      md = null
     }
 
     // markdown

--- a/packages/nuemark/src/parse.js
+++ b/packages/nuemark/src/parse.js
@@ -170,9 +170,15 @@ export function parseBlocks(lines) {
     // code line
     if (fenced) return fenced.content.push(line)
 
-    const trimmed = line.trim()
+    const trimmed = line.trimEnd()
+    // component
+    if (line[0] == '[' && trimmed.slice(-1) == ']' && !line.includes('][')) {
+      comp = parseComponent(trimmed.slice(1, -1))
+      blocks.push(comp)
+      md = null
+
     // component args
-    if (comp) {
+    } else if (comp) {
       const next = getNext(lines, i)
       const indent = getIndent(next)
 
@@ -184,12 +190,6 @@ export function parseBlocks(lines) {
 
       if (!line.trimStart()) comp.body?.push(line)
       else if (!getIndent(line)) comp = null
-   
-    // component
-    } else if (trimmed[0] == '[' && trimmed.slice(-1) == ']' && !line.includes('][')) {
-      comp = parseComponent(trimmed.slice(1, -1))
-      blocks.push(comp)
-      md = null
     }
 
     // markdown

--- a/packages/nuemark/test/nuemark.test.js
+++ b/packages/nuemark/test/nuemark.test.js
@@ -66,6 +66,11 @@ test('nested code with comment', () => {
   expect(html).toInclude('<sup>// hey</sup>')
 })
 
+test('multiple md extensions', () => {
+  const { html } = renderLines(['[.test] ', '\tcontent1', '[.test]', '\tcontent2'])
+  expect(html).toBe('<div class="test"><p>content1</p></div><div class="test"><p>content2</p></div>')
+})
+
 test('parse fenced code', () => {
   const blocks = parseBlocks(['# Hey', '``` md.foo#bar', '// hey', '[foo]', '```'])
   const [hey, fenced] = blocks

--- a/packages/nuemark/test/nuemark.test.js
+++ b/packages/nuemark/test/nuemark.test.js
@@ -68,7 +68,7 @@ test('nested code with comment', () => {
 
 test('multiple md extensions', () => {
   const { html } = renderLines(['[.test] ', '\tcontent1', '[.test]', '\tcontent2'])
-  expect(html).toBe('<div class="test"><p>content1</p></div><div class="test"><p>content2</p></div>')
+  expect(html).toBe('<div class="test"><p>content1</p>\n</div>\n<div class="test"><p>content2</p>\n</div>')
 })
 
 test('parse fenced code', () => {
@@ -124,7 +124,7 @@ test('[tabs] key and wrapper', () => {
 
 
 const NESTED_TABS = `
- [tabs "Foo | Bar"]
+[tabs "Foo | Bar"]
   First
   ---
   Second


### PR DESCRIPTION
Ref #368

Only allows extra spaces at end of line

(Not sure  if this is still needed, when you're done with your markdown parser) 