### PR TITLE
docs: link to edit docs page on gh

### DIFF
--- a/packages/nuejs.org/docs/css/doc-layout.css
+++ b/packages/nuejs.org/docs/css/doc-layout.css
@@ -98,6 +98,8 @@ article + aside {
   }
 }
 
-
-
-
+.edit-page {
+  background: url(/icon/github.svg) 0 50% / 1.25em no-repeat;
+  padding-left: 1.7em;
+  font-size: 90%;
+}

--- a/packages/nuejs.org/docs/layout.html
+++ b/packages/nuejs.org/docs/layout.html
@@ -31,3 +31,5 @@
     </label>
   </div>
 </aside>
+
+<a @name="pagefoot" class="edit-page" href="//github.com/nuejs/nue/edit/master/packages/nuejs.org{url.replace(/\.html$/, '.md').replace(/\/$/, '/index.md')}">Improve this page on GitHub</a>


### PR DESCRIPTION
Adds a link to the md file on gh, to allow editing it without searching for it in the repos.

Feel free to replace the icon e.g. with a pencil icon.

Current look (with url example on hover):
![grafik](https://github.com/user-attachments/assets/1a09fac6-49f3-4cf7-a87a-a84a34cefcbc)

(I tried adding a margin on top, to split the link more from the content, but it was collapsed, and I didn't look any further.)