### PR TITLE
fix(nuemark2): line splitting, import, undefined blocks

### DIFF
--- a/packages/nuemark2/index.js
+++ b/packages/nuemark2/index.js
@@ -1,8 +1,8 @@
 
 import { renderLines } from './src/render-blocks.js'
 import { parseDocument } from './src/document.js'
-import { EOL } from 'node:os'
 
+const EOL = /\r\n|\r|\n/
 
 export function nuemark(str, opts) {
   return renderLines(str.split(EOL), opts)

--- a/packages/nuemark2/src/render-blocks.js
+++ b/packages/nuemark2/src/render-blocks.js
@@ -4,7 +4,7 @@ import { parseLinkTitle } from './parse-inline.js'
 import { parseBlocks } from './parse-blocks.js'
 import { renderTag, wrap } from './render-tag.js'
 import { elem } from './document.js'
-import { glow } from 'glow'
+import { glow } from 'nue-glow'
 
 
 export function renderLines(lines, opts) {

--- a/packages/nuemark2/src/render-tag.js
+++ b/packages/nuemark2/src/render-tag.js
@@ -187,7 +187,7 @@ export function wrap(name, html) {
 }
 
 
-function getInnerHTML(blocks, opts) {
+function getInnerHTML(blocks = [], opts) {
   const [ first, second ] = blocks
   if (!first) return ''
   const { content } = first


### PR DESCRIPTION
This `EOL` from `node:os` does not work for splitting a file on line-endings, because `EOL` is `\n` on Mac/Linux and `\r\n` on Windows. BUT files ´on Windows can also just use `\n` line endings, as Windows can also handle those.

The package from npm is named `nue-glow` not `glow` (and should also have this name in your local installation)

When I ran `bun test` the `block` variable was undefined and some test errored on unpacking.

(There are still routing tests failing, idk why, but I currently don't care about them.)