### PR TITLE
test(dev): fix router test

### DIFF
--- a/packages/nuekit/package.json
+++ b/packages/nuekit/package.json
@@ -17,9 +17,9 @@
     "bun": ">= 1",
     "node": ">= 18"
   },
-	"scripts": {
-		"test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --runInBand"
-	},
+  "scripts": {
+    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --runInBand"
+  },
   "dependencies": {
     "diff-dom": "^5.1.4",
     "es-main": "^1.3.0",

--- a/packages/nuekit/test/page-router.test.js
+++ b/packages/nuekit/test/page-router.test.js
@@ -111,7 +111,7 @@ test('renders "/" route and mount component', async () => {
   const logSpy = jest.spyOn(console, 'log')
 
   await waitFor(() => {
-    expect(document.body.querySelector('[is="app"]').innerHTML.trim()).toBe('<h2>App mounted</h2>')
+    expect(document.body.querySelector('[custom]').innerHTML.trim()).toBe('<h2>App mounted</h2>')
   })
 
   expect(document.title).toBe('Page Router Test - Home')
@@ -156,7 +156,7 @@ test('renders "/page" route and mount component when click in a link', async () 
   )
 
   await waitFor(() => {
-    expect(document.body.querySelector('[is="component"]').innerHTML.trim()).toBe(
+    expect(document.body.querySelector('[custom]').innerHTML.trim()).toBe(
       '<h2>Page component mounted</h2>'
     )
   })

--- a/packages/nuekit/test/page-router.test.js
+++ b/packages/nuekit/test/page-router.test.js
@@ -111,7 +111,7 @@ test('renders "/" route and mount component', async () => {
   const logSpy = jest.spyOn(console, 'log')
 
   await waitFor(() => {
-    expect(document.body.querySelector('[custom]').innerHTML.trim()).toBe('<h2>App mounted</h2>')
+    expect(document.body.querySelector('[custom="app"]').innerHTML.trim()).toBe('<h2>App mounted</h2>')
   })
 
   expect(document.title).toBe('Page Router Test - Home')
@@ -156,7 +156,7 @@ test('renders "/page" route and mount component when click in a link', async () 
   )
 
   await waitFor(() => {
-    expect(document.body.querySelector('[custom]').innerHTML.trim()).toBe(
+    expect(document.body.querySelector('[custom="component"]').innerHTML.trim()).toBe(
       '<h2>Page component mounted</h2>'
     )
   })

--- a/packages/nuemark2/src/render-tag.js
+++ b/packages/nuemark2/src/render-tag.js
@@ -198,7 +198,5 @@ function getInnerHTML(blocks = [], opts) {
 export function renderIsland({ name, attr, data }) {
   const json = !Object.keys(data)[0] ? '' :
     elem('script', { type: 'application/json' }, JSON.stringify(data))
-  ;
-  return elem(name, { 'custom': true, ...attr }, json)
+  return elem(name, { 'custom': name, ...attr }, json)
 }
-

--- a/packages/nuemark2/test/tag.test.js
+++ b/packages/nuemark2/test/tag.test.js
@@ -128,7 +128,7 @@ test('.stack', () => {
 
 test('client-side island', () => {
   const html = renderLines(['[contact-me]', '  cta: Submit'])
-  expect(html).toStartWith('<contact-me custom><script')
+  expect(html).toStartWith('<contact-me custom="contact-me"><script')
 })
 
 


### PR DESCRIPTION
This fixes the router test (mentioned in #375)

> [!Note]
> Problem now is, that you can't identify what a component was, when it is rendered, from the DOM alone.
> What do you think about maybe adding `custom="<name>"` instead of only `custom`?

---

PS: (to https://github.com/nuejs/nue/pull/375#issuecomment-2378462550)
these tests are only slow when they time out.
I agree, that they're maybe complex and error-prone, but that's also, because the API changes.
I hope, that I will take some time to refactor them soon, so they get less complex and error-prone. (Maybe even adding more tests to ensure DOM gets changed as expected.)