### PR TITLE
fix(dev): keep comp name

### DIFF
--- a/packages/nuejs/src/render.js
+++ b/packages/nuejs/src/render.js
@@ -259,7 +259,7 @@ function processNode(opts) {
       // client side component
       if (is_custom && !component) {
         setJSONData(node, data)
-        node.attribs.custom = ""
+        node.attribs.custom = name
         node.name = name
         return // must return
       }

--- a/packages/nuejs/test/render.test.js
+++ b/packages/nuejs/test/render.test.js
@@ -146,7 +146,7 @@ test('Advanced', () => {
     // :attr (:bind works the same on server side)
     '<dd :attr="person"></dd>': '<dd name="Nick" age="0"></dd>',
 
-    '<hey :val/>': '<hey custom>\n  <script type="application/json">{"val":"1"}</script>\n</hey>',
+    '<hey :val/>': '<hey custom="hey">\n  <script type="application/json">{"val":"1"}</script>\n</hey>',
 
     '<html><slot for="none"/><b>{ val }</b></html>': '<html><b>1</b></html>',
     '<html><slot for="page"/></html>': '<html><main>Hello</main></html>',

--- a/packages/nuekit/test/nuekit.test.js
+++ b/packages/nuekit/test/nuekit.test.js
@@ -315,7 +315,7 @@ test('single-page app index', async () => {
   // const html = await readDist(kit.dist, 'index.html')
 
   expect(html).toInclude('hotreload.js')
-  expect(html).toInclude('is="test"')
+  expect(html).toInclude('<test custom="test">')
 })
 
 


### PR DESCRIPTION
Follow up to #376, to also render component `name` to `custom` attribute with `nuejs-core`.

My reasoning: https://github.com/nuejs/nue/pull/376#issuecomment-2380656300

Still, your decision, if you accept this change, or ignore this PR and undo the last commit from #376