### PR TITLE
docs: correct closing nav tag in header components examples

### DIFF
--- a/packages/nuejs.org/docs/page-layout.md
+++ b/packages/nuejs.org/docs/page-layout.md
@@ -382,8 +382,12 @@ This will generate the following:
 
   <!-- the dropdown -->
   <span aria-haspopup>
+    <a aria-expanded="false">More</a>
+
     <nav>
-        <a aria-expanded="false">More</a>
+      <a href="/about/">About Us</a>
+      <a href="/contact/">Contact</a>
+      <a href="/faq/">FAQ</a>
     </nav>
   </span>
 </nav>

--- a/packages/nuejs.org/docs/page-layout.md
+++ b/packages/nuejs.org/docs/page-layout.md
@@ -114,7 +114,7 @@ Now our website has a new `header` element nested directly under the `body`. It 
       <a href="/docs/">Documentation</a>
       <a href="/blog/">Blog</a>
       <a href="/about/">About</a></nav>
-    </hav>
+    </nav>
   </header>
 
   <main>
@@ -277,7 +277,7 @@ This generates the following HTML:
   <a href="/first/link">Link 1 text</a>
   <a href="/second/link" class="pill">Link 2 text</a>
   ...
-</hav>
+</nav>
 ```
 
 #### Nav items
@@ -382,11 +382,11 @@ This will generate the following:
 
   <!-- the dropdown -->
   <span aria-haspopup>
-    <a aria-expanded="false">More</a>
-
     <nav>
+        <a aria-expanded="false">More</a>
     </nav>
   </span>
+</nav>
 ```
 
 The standard [aria-haspopup](//developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) and [aria-expanded](//developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) roles can be used on your CSS to implement the dropdown behavior.


### PR DESCRIPTION
## Description
Fix incorrect closing nav tags (`</hav>` to `</nav>`) in header component documentation.

## Changes
- Corrected HTML examples in header component docs
- Ensured consistency across all affected examples
- Maintained existing documentation style

## Compliance
- Single-purpose PR (documentation fix only)
- No new code or dependencies added
- Follows existing formatting
- No functional changes, so no tests required

## Checklist
- [x] Documentation updated
- [x] Changes verified for consistency


Thank you for reviewing this small but important documentation fix 😉