### PR TITLE
feat(glow): option to disable prefixes / mark

### DIFF
--- a/packages/glow/src/glow.js
+++ b/packages/glow/src/glow.js
@@ -179,7 +179,7 @@ export function parseRow(row, lang) {
 }
 
 function renderString(str) {
-  return encode(str).replace(/\$?\{([^\}]+)\}/g, function (_, content) {
+  return encode(str).replace(/\$?\{([^\}]+)\}/g, function(_, content) {
     return elem('i', _.replace(content, elem('b', content)))
   })
 }
@@ -279,7 +279,7 @@ export function glow(str, opts = { prefix: true, mark: true }) {
     html.push(opts.numbered ? elem('span', line) : line)
   }
 
-  parseSyntax(lines, lang, opts.prefix).forEach(function (block) {
+  parseSyntax(lines, lang, opts.prefix).forEach(function(block) {
     let { line, comment, wrap } = block
 
     // EOL comment

--- a/packages/glow/src/glow.js
+++ b/packages/glow/src/glow.js
@@ -243,11 +243,11 @@ export function parseSyntax(lines, lang, prefix = true) {
 
         // highlighted line
         const c = line[0]
-        const wrap = !prefix ? false : isMD(lang) ? (c == '|' && 'dfn') : PREFIXES[c]
+        const wrap = prefix && (isMD(lang) ? (c == '|' && 'dfn') : PREFIXES[c])
         if (wrap) line = (line[1] == ' ' ? ' ' : '') + line.slice(1)
 
         // escape character
-        if (c == '\\') line = line.slice(1)
+        if (!prefix && c == '\\') line = line.slice(1)
 
         html.push({ line, wrap })
       }

--- a/packages/glow/test/glow.test.js
+++ b/packages/glow/test/glow.test.js
@@ -38,3 +38,23 @@ test('parse JS comment', () => {
   expect(blocks[0].comment).toEqual(['/* First */'])
   expect(blocks[2].comment[0]).toEqual('/*')
 })
+
+
+/* prefix and mark */
+test('disable mark', () => {
+  const html = renderRow('Hey •[img]• girl', undefined, false)
+  expect(html).toInclude('Hey •')
+  expect(html).toInclude('• girl')
+})
+
+test('disable prefixes', () => {
+  const blocks = parseSyntax([
+    '+ not really adding a line',
+    '- not really removing a line',
+    '> not really marking a line'
+  ], undefined, false)
+
+  expect(blocks[0].wrap).toEqual(false)
+  expect(blocks[1].wrap).toEqual(false)
+  expect(blocks[2].wrap).toEqual(false)
+})


### PR DESCRIPTION
Adds ability to just highlight code without worrying to lose some data.
You can just throw in your code, and be sure, that no characters are removed, and just highlighting happens.

Might not be that interesting for nuekit / nuemark, but for use outside of the nue-ecosystem.

[Example](https://nobkd.github.io/nue-editor/): [code change](https://github.com/nobkd/nue-editor/commit/d344256046630cb025d727f2958de79086ababea)

Will probably have to add docs to the readme about these options.