### PR TITLE
perf: keep js builder

### DIFF
--- a/packages/nuekit/src/builder.js
+++ b/packages/nuekit/src/builder.js
@@ -6,10 +6,12 @@ import { join } from 'node:path'
 import { resolve } from 'import-meta-resolve'
 import { Features, bundleAsync } from 'lightningcss'
 
-
+let jsBuilder
 export async function getBuilder(is_esbuild) {
+  if (jsBuilder) return jsBuilder
+
   try {
-    return is_esbuild ? await import(resolve('esbuild', `file://${process.cwd()}/`)) : Bun
+    return jsBuilder = is_esbuild ? await import(resolve('esbuild', `file://${process.cwd()}/`)) : Bun
   } catch {
     throw 'Bundler not found. Please use Bun or install esbuild'
   }


### PR DESCRIPTION
keep js builder instead of re-resolving all the time.

I might need to change some code, so the esbuild tests really use the esbuild builder...
I don't know if it really matters, because it still get's tested on the jest+node test