### PR TITLE
test: cmark spec tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,9 @@
         "js-yaml": "^4.1.0",
         "nue-glow": "*",
       },
+      "devDependencies": {
+        "commonmark-spec": "^0.31.2",
+      },
     },
   },
   "packages": {
@@ -109,6 +112,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.2", "", { "os": "win32", "cpu": "x64" }, "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "commonmark-spec": ["commonmark-spec@0.31.2", "", {}, "sha512-vXKxmclzJPymhOJYD26G0oBjVmIcKC8p5m2DvHIq1A1btr1m0r0dT/PzRA5/nwxUbCAPedMNPEoiQE+zvuOcOw=="],
 
     "detect-libc": ["detect-libc@2.0.3", "", {}, "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="],
 

--- a/packages/nuemark/package.json
+++ b/packages/nuemark/package.json
@@ -18,6 +18,9 @@
     "js-yaml": "^4.1.0",
     "nue-glow": "*"
   },
+  "devDependencies": {
+    "commonmark-spec": "^0.31.2"
+  },
   "jest": {
     "setupFilesAfterEnv": [
       "<rootDir>/../../setup-jest.js"

--- a/packages/nuemark/test/cmark.test.js
+++ b/packages/nuemark/test/cmark.test.js
@@ -1,0 +1,20 @@
+import { tests } from 'commonmark-spec'
+import { nuemark } from '../index.js'
+
+tests.forEach(v => {
+    v.markdown = v.markdown.replaceAll('→', '\t').trimEnd()
+    v.html = v.html.replaceAll('→', '\t').trimEnd()
+})
+
+const skipSections = ['Tabs', 'Indented code blocks', 'Raw HTML', 'HTML blocks']
+const skipNumbers = []
+
+for (const testCase of tests) {
+    if (skipSections.includes(testCase.section) ||
+        skipNumbers.includes(testCase.number)) continue
+
+    test(`cmark spec: ${testCase.section}; ${testCase.number}`, () => {
+        console.log(testCase.number, JSON.stringify(testCase.markdown))
+        expect(nuemark(testCase.markdown)).toEqual(testCase.html)
+    })
+}


### PR DESCRIPTION
tests that should fail with our md variant should be excluded. e.g. Tabs code blocks aren't supported by nuemark e.g. because of nested nuemark tags

Edit: maybe my exclusion of tests currently is a bit too much 

Ref: https://github.com/nuejs/nue/issues/379#issuecomment-2430230905