### PR TITLE
feat: add alternative nue.yaml config filename

### DIFF
--- a/packages/examples/simple-blog/site.yaml
+++ b/packages/examples/simple-blog/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/nuejs-site.json
 
 globals: ["@global"]
 libs: ["@library"]

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -41,6 +41,7 @@ export async function createSite(args) {
   }
 
   async function readData(path) {
+    if (!path) return
     try {
       const raw = await read(path)
       return yaml.load(raw)


### PR DESCRIPTION
I have [submitted a JSON Schema](https://github.com/SchemaStore/schemastore/pull/4218) describing the Nue `site.yaml` file to schemastore.org in order to get editor support for the Nue config (autoexpand and validation). ~~However, since the `site.yaml` filename is generic, it is not ideal for file matching (needed for convenient auto-detection of the schema).~~

~~Thus, it would be nice to add an alternative filename, `nue.yaml`, which could be autodetected. I don't want to make a breaking change and propose changing it, but allowing both would work too.~~

~~This PR extends Nue to support either filename.~~

Update: The PR now simply adds a reference to the schema allowing editors to use it; and fixes a minor bug where `readData` would fail on missing path instead of returning.

Related: <https://github.com/nuejs/nue/issues/407>
