### PR TITLE
feat: `base` CLI option

### DIFF
--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -56,6 +56,7 @@ export function getArgs(argv) {
       else if (['-e', '--environment'].includes(arg)) opt = 'env'
       else if (['-r', '--root'].includes(arg)) opt = 'root'
       else if (['-P', '--port'].includes(arg)) opt = 'port'
+      else if (['-B', '--base'].includes(arg)) opt = 'base'
 
       // bad options
       else throw `Unknown option: "${arg}"`

--- a/packages/nuekit/src/site.js
+++ b/packages/nuekit/src/site.js
@@ -76,6 +76,7 @@ export async function createSite(args) {
 
   const dist = joinRootPath(root, site_data.dist || join('.dist', is_prod ? 'prod' : 'dev'))
   const port = args.port || site_data.port || (is_prod ? 8081 : 8080)
+  site_data.base = args.base || site_data.base
 
 
   // flag if .dist is empty


### PR DESCRIPTION
fix #416

Add CLI option for `base`.

Currently not added to CLI help, because I think the following:

Maybe the logic for `base` has to be changed a bit, so you don't have to prefix it with a forward slash (`/`), but that's unrelated to this PR.
And currently you have to design your paths so, that they're relative. absolute paths are not prefixed properly in all the needed cases I think. (Also goes for custom `favicon` I think)