### PR TITLE
fix(glow): escaping line start

### DIFF
--- a/packages/glow/src/glow.js
+++ b/packages/glow/src/glow.js
@@ -213,8 +213,8 @@ export function renderRow(row, lang, mark=true) {
   ret.push(row.substring(index))
   const res = ret.join('')
 
-  return !mark ? res : res.replace(MARK, (_, a, b, c) => {
-    return elem(a[1] ? 'u' : 'mark', b)
+  return !mark ? res : res.replace(MARK, (_, marker, content) => {
+    return elem(marker[1] ? 'u' : 'mark', content)
   })
 }
 
@@ -247,7 +247,7 @@ export function parseSyntax(lines, lang, prefix = true) {
         if (wrap) line = (line[1] == ' ' ? ' ' : '') + line.slice(1)
 
         // escape character
-        if (!prefix && c == '\\') line = line.slice(1)
+        if (prefix && c == '\\') line = line.slice(1)
 
         html.push({ line, wrap })
       }

--- a/packages/glow/test/glow.test.js
+++ b/packages/glow/test/glow.test.js
@@ -47,6 +47,18 @@ test('disable mark', () => {
   expect(html).toInclude('• girl')
 })
 
+test('escape prefixes', () => {
+  const blocks = parseSyntax([
+    '\\+ not really adding a line',
+    '\\- not really removing a line',
+    '\\| not really marking a line'
+  ], 'md')
+
+  expect(blocks[0].line).toEqual('+ not really adding a line')
+  expect(blocks[1].line).toEqual('- not really removing a line')
+  expect(blocks[2].line).toEqual('| not really marking a line')
+})
+
 test('disable prefixes', () => {
   const blocks = parseSyntax([
     '+ not really adding a line',


### PR DESCRIPTION
Sorry, seems I wrongly added a `not` operator there.. (see L250)

Fix for first part of https://github.com/nuejs/nue/issues/379#issuecomment-2481323942.


---

Additional changes:
- fixed naming of `mark` replacement function

---

Off topic:
Using more than 3 backticks on both code block ends still does not work. That would be part of `nuemark`. (The end of the fenced code block can have more characters than the start, but must have at least as many as the start (per CommonMark iirc))