### PR TITLE
test(lychee): fragments

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -25,9 +25,10 @@ jobs:
         with:
           args: >
             --no-progress
-            --exclude-path node_modules
-            --exclude localhost
-            --base .
+            --include-fragments
+            --exclude-path "node_modules"
+            --exclude "localhost"
+            --base "."
             --
             "**/README.md"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -60,6 +61,7 @@ jobs:
         with:
           args: >
             --no-progress
+            --include-fragments
             --accept "403, 429, 503, 999"
             --remap "http://localhost:8080/@ https://nuejs.org/@"
             --remap "http://localhost:8080/todomvc https://nuejs.org/todomvc"


### PR DESCRIPTION
Add fragment (`#anchor`) checks

Maybe does nothing on current lychee version, as it was accidentally broken as far as I read. Will have to that check again. 
Yup: https://github.com/lycheeverse/lychee/issues/1613#issuecomment-2588686613

Still merging, should add additional checks in the future on new releases