### PR TITLE
fix: starting lists in anonynous block tag

### DIFF
--- a/packages/nuemark/src/parse-blocks.js
+++ b/packages/nuemark/src/parse-blocks.js
@@ -182,7 +182,7 @@ function processNestedBlocks(block, capture) {
     const body = block.body.join('\n')
 
     try {
-      if (body && name != '.' && isYAML(body.trim())) {
+      if (body && name && isYAML(body.trim())) {
         let data = parseYAML(body)
         if (Array.isArray(data)) data = { items: data }
         Object.assign(block.data, data)

--- a/packages/nuemark/src/render-tag.js
+++ b/packages/nuemark/src/render-tag.js
@@ -147,7 +147,6 @@ export function renderTag(tag, opts={}) {
   if (!fn) return renderIsland(tag, opts.data)
 
   const data = { ...opts.data, ...extractData(tag.data, opts.data) }
-  const { blocks } = tag
 
   const api = {
     ...tag,

--- a/packages/nuemark/test/tag.test.js
+++ b/packages/nuemark/test/tag.test.js
@@ -120,6 +120,11 @@ test('[list] wrapper', () => {
 
 
 // anonymous tag
+test('.list', () => {
+  const html = renderLines(['[.list]', '  - elem 1', '  - elem 2'])
+  expect(html).toBe('<div class="list"><ul><li><p>elem 1</p></li>\n<li><p>elem 2</p></li></ul></div>')
+})
+
 test('.note', () => {
   const html = renderLines(['[.note]', '  ## Note', '  Hello'])
   expect(html).toBe('<div class="note"><h2>Note</h2>\n<p>Hello</p></div>')


### PR DESCRIPTION
fixes #471 

- I don't know, when the component name could be a single dot, so it's a null check now
- change in `render-tag.js` was just an unused var

This might still show unprecedented behavior for custom tags, but it shouldn't crash anymore at least. Custom tags will need some more handling, if the content is really YAML.