### PR TITLE
feat(nuemark)!: proposal to use different section separator

### DIFF
--- a/packages/examples/simple-blog/contact/index.md
+++ b/packages/examples/simple-blog/contact/index.md
@@ -10,7 +10,7 @@ title: Contact me
   
   [contact-me]
 
-  ---
+  +++
   [image]
     src: /img/profile.jpg
     size: 460 x 460

--- a/packages/nuejs.org/blog/rethinking-reactivity/index.md
+++ b/packages/nuejs.org/blog/rethinking-reactivity/index.md
@@ -82,7 +82,7 @@ To understand this choice we must go back in time. The world used to be slightly
   - Accessibility
   - UI libraries
 
-  ---
+  +++
   ### JS development
   - Advanced TypeScript/JS
   - Business logic

--- a/packages/nuejs.org/blog/tailwind-vs-semantic-css/index.md
+++ b/packages/nuejs.org/blog/tailwind-vs-semantic-css/index.md
@@ -13,7 +13,7 @@ This study compares two websites with similar design: The commercial Spotlight t
     href: //spotlight.tailwindui.com/
     small: img/tw-home.png
     large: img/tw-home-big.png
-  ---
+  +++
   [image]
     href: /@spotlight/
     large: img/nue-home-big.png
@@ -117,7 +117,7 @@ Here's a better example. Let's look at the "Uses" or "Setup" page on both implem
     small: img/tw-uses.png
     large: img/tw-uses-big.png
     caption: Tailwind UI version →
-  ---
+  +++
   [image]
     href: /@spotlight/setup/
     large: img/nue-uses-big.png

--- a/packages/nuejs.org/docs/_content-syntax.md
+++ b/packages/nuejs.org/docs/_content-syntax.md
@@ -154,7 +154,7 @@ This expanded capability allows you to reference full concepts or phrases, impro
 
 
 ### Sections
-You can split your content into sections with a triple dash `---` making your content render like this:
+You can split your content into sections with a triple plus `+++` making your content render like this:
 
 ```
 <article>
@@ -274,7 +274,7 @@ And when styled with CSS, it takes on a visually structured layout:
 [render]
 
 #### Separator
-Nue automatically uses the first `h2` or `h3` tag within a block as the **separator** for the content blocks. If needed, you can use a **triple-dash** (`---`) as an explicit separator to customize content divisions.
+Nue automatically uses the first `h2` or `h3` tag within a block as the **separator** for the content blocks. If needed, you can use a **triple-plus** (`+++`) as an explicit separator to customize content divisions.
 
 For example:
 
@@ -283,7 +283,7 @@ For example:
   ### Design
   Design blends form and function.
 
-  ---
+  +++
 
   ### Engineering
   Code enhances the user experience while staying performant.

--- a/packages/nuejs.org/docs/content-tags.md
+++ b/packages/nuejs.org/docs/content-tags.md
@@ -459,14 +459,14 @@ You can apply a specific class for styling. Here’s an example using `.card` to
 
 ### Defining separators
 
-Nue uses the first heading element (`h2` or `h3`) to create new accordion entries automatically. Alternatively, use the triple-dash (`---`) separator to define new entries explicitly:
+Nue uses the first heading element (`h2` or `h3`) to create new accordion entries automatically. Alternatively, use the triple-plus (`+++`) separator to define new entries explicitly:
 
 ```md
 [accordion]
   ## First element
   The contents of the first element.
 
-  ---
+  +++
 
   ## Second element
   The contents of the second element.

--- a/packages/nuejs.org/docs/content.md
+++ b/packages/nuejs.org/docs/content.md
@@ -100,16 +100,16 @@ This generates sections with corresponding class names:
 
 ### Manual sections
 
-For more granular control, you can use triple dashes (`---`) to explicitly create section breaks:
+For more granular control, you can use triple pluses (`+++`) to explicitly create section breaks:
 
 ```md
 First section content...
 
----
++++
 
 Second section content...
 
----
++++
 
 Third section content...
 ```
@@ -175,19 +175,19 @@ This generates:
 </div>
 ```
 
-You can also create more flexible grid layouts using triple dash as separator:
+You can also create more flexible grid layouts using triple plus as separator:
 
 ```md
 [.grid]
   [image feature-1.jpg]
   First feature description
 
-  ---
+  +++
 
   [image feature-2.jpg]
   Second feature description
 
-  ---
+  +++
 
   [image feature-3.jpg]
   Third feature description

--- a/packages/nuejs.org/docs/styling.md
+++ b/packages/nuejs.org/docs/styling.md
@@ -181,7 +181,7 @@ Once your content is split into sections, you can style each section individuall
 
 Nue can automatically split your content into sections based on `<h2>` headings. Each `<h2>` tag starts a new section, and the section is automatically assigned a class matching the heading (e.g., `.hero`, `.features`). This allows you to structure your content naturally without manually managing section breaks.
 
-Alternatively, you can manually define section breaks using three dashes `---` in your Markdown or YAML configuration for greater control.
+Alternatively, you can manually define section breaks using three pluses `+++` in your Markdown or YAML configuration for greater control.
 
 #### Reusing section styles for consistency
 

--- a/packages/nuejs.org/index.md
+++ b/packages/nuejs.org/index.md
@@ -1,5 +1,5 @@
 ---
-sections: [hero, clean-slate, rebirth ]
+sections: [hero, stats-section, clean-slate, rebirth ]
 include: [form, video]
 inline_css: true
 appdir: home
@@ -13,18 +13,18 @@ Nue is **HTML**, **CSS**, and **JavaScript** taken to their absolute peak
   Read the announcement ›
 [button.ghost "Get started →" href="/docs/installation.html"]
 
----
++++
 [.stats]
   Around
   ## 30× smaller
   Binary than Next.js [[1]](/docs/compare.html#install)
 
-  ---
+  +++
   Around
   ## 100× faster
   Tooling than Next.js [[2]](/docs/compare.html#build)
 
-  ---
+  +++
   Around
   ## 30× lighter
   Results than in Next.js [[3]](/docs/compare.html#output)
@@ -36,7 +36,7 @@ Nue is **HTML**, **CSS**, and **JavaScript** taken to their absolute peak
   — **Mauricio Wolff**, design engineering lead at **Loom**
 
 
-----
++++
 ## A clean slate
 Nue is built from scratch to get web development back on its track
 
@@ -56,7 +56,7 @@ Nue is built from scratch to get web development back on its track
   **Elliot Jay Stocks**, Pioneer in semantic HTML
 
 
-----
++++
 ## A rebirth of the frontend
 Nue makes a full cleanup for the overly complex ecosystem
 
@@ -70,4 +70,3 @@ Nue makes a full cleanup for the overly complex ecosystem
   alt: Nue roadmap
 
 [feedback]
-

--- a/packages/nuejs.org/tour/1-tooling/hmr.md
+++ b/packages/nuejs.org/tour/1-tooling/hmr.md
@@ -17,6 +17,6 @@
     Page changes          |         | ×
     CSS errors            |         | ×
 
-  ---
+  +++
 
   [image /tour/img/hmr-hero.png]

--- a/packages/nuejs.org/tour/1-tooling/speed-compare.md
+++ b/packages/nuejs.org/tour/1-tooling/speed-compare.md
@@ -9,7 +9,7 @@ class: compare-page
   [bunny-video]
     videoId: d9ebcf29-9314-4571-856c-0dfa7f49d6d1
     width: 587
-  ---
+  +++
   ## Nue blog *0.1 seconds to build*
   [bunny-video]
     videoId: 7bcfcde2-912c-4c30-a442-198bc25ba250

--- a/packages/nuejs.org/tour/1-tooling/speed.md
+++ b/packages/nuejs.org/tour/1-tooling/speed.md
@@ -12,6 +12,6 @@
   [button "Show me"]
     href: speed-compare.html
 
-  ---
+  +++
 
   [image /tour/img/simple-blog.png]

--- a/packages/nuejs.org/tour/1-tooling/stuff.md
+++ b/packages/nuejs.org/tour/1-tooling/stuff.md
@@ -6,6 +6,6 @@
 
   [button "Show the difference"]
     href: stuff-compare.html
-  ---
+  +++
 
   [image /tour/img/simple-blog.png]

--- a/packages/nuejs.org/tour/2-code/codebase.md
+++ b/packages/nuejs.org/tour/2-code/codebase.md
@@ -13,6 +13,6 @@
   [button "See the difference"]
     href: codebase-compare.html
 
-  ---
+  +++
 
   [image /tour/img/simple-blog.png]

--- a/packages/nuejs.org/tour/2-code/content.md
+++ b/packages/nuejs.org/tour/2-code/content.md
@@ -7,6 +7,6 @@
   [button "See the difference"]
     href: content-compare.html
 
-  ---
+  +++
 
   [image ../img/content-hero.png]

--- a/packages/nuejs.org/tour/2-code/standards.md
+++ b/packages/nuejs.org/tour/2-code/standards.md
@@ -7,6 +7,6 @@
   [button "See the difference"]
     href: standards-compare.html
 
-  ---
+  +++
 
   [image /tour/img/button-hero.png]

--- a/packages/nuejs.org/tour/3-websites/motion.md
+++ b/packages/nuejs.org/tour/3-websites/motion.md
@@ -7,6 +7,6 @@
   [button "See the difference"]
     href: motion-demo.html
 
-  ---
+  +++
 
   [! /tour/img/simple-blog-hero.png ]

--- a/packages/nuejs.org/tour/3-websites/size.md
+++ b/packages/nuejs.org/tour/3-websites/size.md
@@ -14,6 +14,6 @@
     JavaScript        | 531kB     | 7kB      | 75 × less
     Total             | 644kB     | 19kB     | 34 × less
 
-  ---
+  +++
 
   [image /tour/img/documentation.png]

--- a/packages/nuejs.org/tour/3-websites/templates.md
+++ b/packages/nuejs.org/tour/3-websites/templates.md
@@ -10,6 +10,6 @@ class: nike
   [button "Show the difference"]
     href: templates-demo.html
 
-  ---
+  +++
 
   [! /tour/img/ux-templates.png ]

--- a/packages/nuejs.org/tour/intro.md
+++ b/packages/nuejs.org/tour/intro.md
@@ -12,7 +12,7 @@ class: intro
   - Hot-reload anything
 
   [Show me how](/tour/1-tooling/speed.html)
-  ---
+  +++
 
   [! /tour/icon/code.svg]
   ## Better code
@@ -21,7 +21,7 @@ class: intro
   - Design engineering
 
   [Show me how](/tour/2-code/content.html)
-  ---
+  +++
 
   [! /tour/icon/globe.svg]
   ## Better websites

--- a/packages/nuejs.org/tour/roadmap.md
+++ b/packages/nuejs.org/tour/roadmap.md
@@ -8,7 +8,7 @@ class: compare-page
   # Roadmap
   For becominmg the UX framework for the Web
 
-  ---
+  +++
 
   1. ## Nue 1.0
     * •Smooth onboarding•

--- a/packages/nuemark/src/parse-blocks.js
+++ b/packages/nuemark/src/parse-blocks.js
@@ -239,11 +239,11 @@ function getListItem(line) {
 }
 
 export function getBreak(str) {
-  const HR = ['---', '***', '___', '- - -', '* * *']
+  const HR = ['+++', '---', '***', '___', '- - -', '* * *']
 
   for (const hr of HR) {
-    if (str.startsWith(hr) && !/[^\*\-\_ ]/.test(str)) {
-      return { is_break: true, is_separator: hr == '---' }
+    if (str.startsWith(hr) && !/[^-_+* ]/.test(str)) {
+      return { is_break: true, is_separator: hr == '+++' }
     }
   }
 }

--- a/packages/nuemark/test/block.test.js
+++ b/packages/nuemark/test/block.test.js
@@ -66,7 +66,7 @@ test('multiple thematic breaks', () => {
 
 
 test('parse thematic break', () => {
-  const hrs = ['***', '___', '- - -', '*** --- ***']
+  const hrs = ['+++', '---', '***', '___', '- - -', '*** --- ***']
   for (const str of hrs) {
     expect(getBreak(str)).toBeDefined()
   }

--- a/packages/nuemark/test/document.test.js
+++ b/packages/nuemark/test/document.test.js
@@ -65,7 +65,7 @@ test('multiple sections', () => {
   const lines = [
     '# Hello', 'World',
     '## Foo', 'Bar',
-    '---', 'Bruh', '***',
+    '+++', 'Bruh', '---',
   ]
 
   const doc = parseDocument(lines)
@@ -73,6 +73,7 @@ test('multiple sections', () => {
 
   const html = doc.render({ sections: ['hero'] })
   expect(html).toStartWith('<section class="hero"><h1>Hello</h1>')
+  expect(html).toInclude('</section>\n\n<section>')
   expect(html).toEndWith('<hr></section>')
 })
 

--- a/packages/nuemark/test/document.test.js
+++ b/packages/nuemark/test/document.test.js
@@ -44,9 +44,9 @@ test('sectionize', () => {
   const tests = [
     ['### h3', 'para', '### h3', 'para', '#### h4', 'para'],
     ['# h1', 'para', '## h2', 'para', '### h3', 'para'],
-    ['para', '## h3', '---', 'para', '## h2'],
-    ['## lol', '---', '## bol'],
-    ['lol', '---', 'bol'],
+    ['para', '## h3', '+++', 'para', '## h2'],
+    ['## lol', '+++', '## bol'],
+    ['lol', '+++', 'bol'],
   ]
 
   for (const test of tests) {

--- a/packages/nuemark/test/tag.test.js
+++ b/packages/nuemark/test/tag.test.js
@@ -132,7 +132,7 @@ test('.note', () => {
 
 // anonymous .stack
 test('.stack', () => {
-  const html = renderLines(['[.stack]', '  Hey', '  ---', '  Girl'])
+  const html = renderLines(['[.stack]', '  Hey', '  +++', '  Girl'])
   expect(html).toStartWith('<div class="stack"><div><p>Hey</p></div>')
 })
 


### PR DESCRIPTION
- link https://github.com/nuejs/nue/issues/379#issuecomment-2528041394

Increase cmark compatibility by a tiny bit.

Use `+++` as section separator, makes it clear, that no traditional `<hr>` is used

```rst
hello section 1

+++

hello section 2
```