### PR TITLE
docs: fix some links

### DIFF
--- a/packages/nuejs.org/blog/introducing-nuemark/index.md
+++ b/packages/nuejs.org/blog/introducing-nuemark/index.md
@@ -137,7 +137,7 @@ ps: Check out [Getting started docs](/docs/#node) if you prefer Node.
 ### Learn Nuemark
 
 - [User guide](/docs/content.html)
-- [Tag reference](/docs/tags.html)
+- [Tag reference](/docs/content-tags.html)
 - [HTML output](/docs/page-layout.html#md)
 
 

--- a/packages/nuejs.org/blog/nue-1-beta/index.md
+++ b/packages/nuejs.org/blog/nue-1-beta/index.md
@@ -128,7 +128,7 @@ There are no longer hard coded `app.yaml`, `layout.html`, or `main.js` file name
 
 
 ### Dynamic sections and grid items
-You can turn your [sections](/docs/page-layout.html#sections) and [grid items](/docs/reactivity.html#grid-items) into a native Web Component. For example, on the front page of this website, we have a "scroll-transition" component to help implement all the scroll-triggered CSS transitions.
+You can turn your [sections](/docs/content.html#sections) and [grid items](/docs/reactivity.html#grid-items) into a native Web Component. For example, on the front page of this website, we have a "scroll-transition" component to help implement all the scroll-triggered CSS transitions.
 
 ```yaml
 section_component: scroll-transition

--- a/packages/nuejs.org/blog/nue-1-beta/index.md
+++ b/packages/nuejs.org/blog/nue-1-beta/index.md
@@ -138,13 +138,13 @@ The web component can be assigned globally in `site.yaml` for all page sections 
 
 
 ### Miscellaneous new features
-- New `<navi>`, `<markdown>`, `<pretty-date>`, and `<toc>` tags to help building [custom layouts](/docs/custom-layouts.html)
+- New `<navi>`, `<markdown>`, `<pretty-date>`, and `<toc>` tags to help building [custom layouts](/docs/layout.html)
 
 - A new [`<gallery>`](/docs/content-collections.html#gallery) tag to render content collections
 
 - Inline SVG support: You can inline your SVG files with a new inline attribute. For example: `[image /img/my-animated.svg inline]`. This allows you to control the image and its transitions/animations with CSS.
 
-- Files with a `.htm` suffix are treated as [client-side components](/docs/reactive-components.html). Now both `.nue` and `.htm` files are treated the same.
+- Files with a `.htm` suffix are treated as [client-side components](/docs/islands.html). Now both `.nue` and `.htm` files are treated the same.
 
 - Blog entries are now sorted by both `pubDate` and a new, shorter `date` property.
 

--- a/packages/nuejs.org/blog/nuekit-010/index.md
+++ b/packages/nuejs.org/blog/nuekit-010/index.md
@@ -65,11 +65,11 @@ Nue is an order of magnitude faster than its cousins. An identical blogging site
 ## Other notable highlights { #other }
 
 - [View transitions](/docs/reactivity.html)
-- [Layout components](/docs/custom-layouts.html)
+- [Layout components](/docs/layout.html)
 - [JS/TypeScript modules](/docs/reactivity.html)
 - [Content collections](/docs/content-collections.html)
-- [Reactive components](/docs/reactive-components.html)
-- [Extreme performance](/docs/performance-optimization.html)
+- [Reactive components](/docs/islands.html)
+- [Extreme performance](/docs/optimization.html)
 
 
 ### New, beautiful documentation area

--- a/packages/nuejs.org/docs/content-tags.md
+++ b/packages/nuejs.org/docs/content-tags.md
@@ -5,7 +5,7 @@ include: [tabs]
 # Built-in Markdown extensions
 Nue extends Markdown with a set of built-in tags that enhance content creation.
 
-These tags use a simple bracket syntax - `[image]` for images, `[button]` for buttons, `[video]` for videos - to add functionality while maintaining readable content. These tags allow you to:
+These tags use a simple bracket syntax — `[image]` for images, `[button]` for buttons, `[video]` for videos — to add functionality while maintaining readable content. These tags allow you to:
 
 1. Add dialogs, accordions, and tabs while staying in Markdown
 2. Create sophisticated layouts that preserve content structure

--- a/packages/nuejs.org/docs/css-best-practices.md
+++ b/packages/nuejs.org/docs/css-best-practices.md
@@ -46,7 +46,7 @@ When drafting your [design system](ux-development.html#design-system) limit your
 
 
 ## Organize your CSS { #organize }
-Your CSS code is applied to a standardized [HTML layout](page-layout.html) in the global design system. This CSS should be organized in such a way that the colors, elements and components are aligned with your design system.
+Your CSS code is applied to a standardized [HTML layout](layout.html) in the global design system. This CSS should be organized in such a way that the colors, elements and components are aligned with your design system.
 
 [image]
   small: /img/figma-to-css.png
@@ -90,7 +90,7 @@ Place all page-specific CSS under the leaf folder, where the `index.md` file res
 
 
 ## Use simple selectors { #selectors }
-One hugely important thing in the global design system is that you always know the exact [page layout](page-layout.html) you are styling. This allows you to take advantage of the global scope and use the simplest CSS selectors possible without worrying about conflicts.
+One hugely important thing in the global design system is that you always know the exact [page layout](layout.html) you are styling. This allows you to take advantage of the global scope and use the simplest CSS selectors possible without worrying about conflicts.
 
 
 ```css
@@ -124,7 +124,7 @@ Simple selectors make your CSS easy to read and maintain. They keep your file si
 
 
 ## Write clean HTML { #clean-markup }
-Avoid using unnecessary divs, spans and class names in your [custom layouts](custom-layouts.html):
+Avoid using unnecessary divs, spans and class names in your [custom layouts](layout.html):
 
 ```html.bad "Unnecessary divs and class names"
 <div class="chat-notification">

--- a/packages/nuejs.org/docs/reactivity.md
+++ b/packages/nuejs.org/docs/reactivity.md
@@ -249,7 +249,7 @@ Reactive islands are interactive components within the server-rendered, static H
 ```
 
 
-After saving the component to a file with `.htm` or `.nue` extension, you can use it in your Markdown content as follows:
+After saving the component to a file with `.htm` or `.dthml` extension, you can use it in your Markdown content as follows:
 
 
 ```md
@@ -258,7 +258,7 @@ After saving the component to a file with `.htm` or `.nue` extension, you can us
 > [join-list cta="Submit form"]
 ```
 
-The component can also be used on your [layout files](custom-layouts.html):
+The component can also be used in your [layout files](layout.html):
 
 ```html
 <join-list cta="Submit form"/>
@@ -310,7 +310,7 @@ addEventListener('click', e => {
 
 
 ### Google Analytics
-Google Analytics and other scripts that must be imported externally should go to the head section of your website. This happens by adding a custom `head` element to a root level [layout file](custom-layouts.html):
+Google Analytics and other scripts that must be imported externally should go to the head section of your website. This happens by adding a custom `head` element to a root level [layout file](layout.html):
 
 
 ```html

--- a/packages/nuejs.org/docs/reactivity.md
+++ b/packages/nuejs.org/docs/reactivity.md
@@ -120,7 +120,7 @@ One major benefit of using a Web Component is that the browser automatically tak
 
 
 ### Dynamic sections { #sections }
-You can turn all the [page sections](page-layout.html#sections) into web components with a `section_component` configuration option. This can be assigned in the front matter or globally in the application data. On the front page of this website, for example, we have a "scroll-transition" component to help implement all the scroll-triggered CSS transitions:
+You can turn all the [page sections](content.html#sections) into web components with a `section_component` configuration option. This can be assigned in the front matter or globally in the application data. On the front page of this website, for example, we have a "scroll-transition" component to help implement all the scroll-triggered CSS transitions:
 
 ```yaml
 section_component: scroll-transition

--- a/packages/nuejs.org/docs/styling.md
+++ b/packages/nuejs.org/docs/styling.md
@@ -201,7 +201,7 @@ A content-first approach ensures that your design system is tailored to the real
 
 ### Use clean, semantic HTML
 
-When building your [layouts](layout.html) and [Markdown extensions](markdown-extensions.html), always prioritize clean, semantic HTML. Avoid unnecessary `<div>` and `<span>` elements, and remove class names that are purely for styling purposes. By doing so, your HTML becomes more accessible, SEO-friendly, and easier to maintain. It also aligns perfectly with the principles of a **design system** by ensuring that styles are applied consistently and meaningfully.
+When building your [layouts](layout.html) and [Markdown extensions](content-tags.html), always prioritize clean, semantic HTML. Avoid unnecessary `<div>` and `<span>` elements, and remove class names that are purely for styling purposes. By doing so, your HTML becomes more accessible, SEO-friendly, and easier to maintain. It also aligns perfectly with the principles of a **design system** by ensuring that styles are applied consistently and meaningfully.
 
 Instead of this:
 

--- a/packages/nuejs.org/docs/syntax-highlighting.md
+++ b/packages/nuejs.org/docs/syntax-highlighting.md
@@ -13,7 +13,7 @@ Nue uses the built-in syntax highlighter, [Glow](/blog/introducing-glow/), to st
 
 - **Small footprint**: The CSS for highlighting all languages is under 1 KB, including support for highlighted lines and regions.
 
-For details on adding code blocks to your Markdown documents, refer to the [code syntax](content-tags.html#code-blocks) guide. This article also explains how to adjust the look and feel of the generated HTML.
+For details on adding code blocks to your Markdown documents, refer to the [code syntax](content-syntax.html#code-blocks) guide. This article also explains how to adjust the look and feel of the generated HTML.
 
 
 ## The HTML output

--- a/packages/nuejs.org/docs/syntax-highlighting.md
+++ b/packages/nuejs.org/docs/syntax-highlighting.md
@@ -13,7 +13,7 @@ Nue uses the built-in syntax highlighter, [Glow](/blog/introducing-glow/), to st
 
 - **Small footprint**: The CSS for highlighting all languages is under 1 KB, including support for highlighted lines and regions.
 
-For details on adding code blocks to your Markdown documents, refer to the [code syntax](content-syntax.html#code-blocks) guide. This article also explains how to adjust the look and feel of the generated HTML.
+For details on adding code blocks to your Markdown documents, refer to the [code syntax](content-tags.html#code-blocks) guide. This article also explains how to adjust the look and feel of the generated HTML.
 
 
 ## The HTML output

--- a/packages/nuejs.org/home/roadmap.yaml
+++ b/packages/nuejs.org/home/roadmap.yaml
@@ -12,7 +12,7 @@ roadmap:
       - package: nuemark
         title: Extended Markdown
         desc: Custom parser for rich, interactive websites
-        href: /docs/content-syntax.html
+        href: /docs/content-tags.html
 
       - package: nuejs
         title: HTML components


### PR DESCRIPTION
> [!Note]
> I also changed some links which pointed to `content-syntax`, since you moved it to `_content-syntax.md`.
> Not sure, if this was accidental, or if you want to remove that file in the future, though!

Also not sure, what to do about most of the broken links that are left over. Since the create repo doesn't exist anymore, the links to the examples/templates are, and will obviously stay broken.

Please check, if you think the changed links are pointing to places you intended them to point to.