### PR TITLE
Collection of small create, cli, version, helper changes

### DIFF
--- a/packages/nuekit/src/cli-help.js
+++ b/packages/nuekit/src/cli-help.js
@@ -1,4 +1,4 @@
-import { colors, openUrl, version } from './util.js'
+import { colors, version } from './util.js'
 
 const HELP = `
 Usage
@@ -11,6 +11,7 @@ Commands
   build    Build the site under <root_dir>
   create   Use a project starter template
   init     Re-generate /@nue system files
+  docs     Open Nue's docs
 
 Options
   -r or --root          Source directory. Default "." (current working dir)
@@ -19,7 +20,8 @@ Options
   -n or --dry-run       Show what would be built. Does not create outputs
   -b or --esbuild       Use esbuild as JS bundler. Please install it manually
   -l or --lcss          Use lightningcss as CSS bundler. Please install it manually
-  -P or --port          Port to serve the site on
+  -P or --port          Serves the site on the specified port
+  -o or --open          Opens the local site in the browser
 
 File matches
   Only build files that match the rest of the arguments. For example:
@@ -39,7 +41,7 @@ Examples
   nue build .md .css
 
   # more examples
-  https://nuejs.org/docs/command-line-interface.html
+  Visit https://nuejs.org/docs/command-line-interface.html
 
  ┏━┓┏┓┏┳━━┓
  ┃┏┓┫┃┃┃┃━┫  ${version}
@@ -47,7 +49,7 @@ Examples
  ┗┛┗┻━━┻━━┛
 `
 
-const commands = ['serve', 'build', 'init', 'create']
+const commands = ['serve', 'build', 'init', 'create', 'docs']
 
 function formatLine(line) {
   const { gray, magenta, cyan, green } = colors

--- a/packages/nuekit/src/cli-help.js
+++ b/packages/nuekit/src/cli-help.js
@@ -1,4 +1,4 @@
-import { colors, openUrl, getVersion } from './util.js'
+import { colors, openUrl, version } from './util.js'
 
 const HELP = `
 Usage
@@ -39,10 +39,10 @@ Examples
   nue build .md .css
 
   # more examples
-  ${openUrl} https://nuejs.org/docs/command-line-interface.html
+  https://nuejs.org/docs/command-line-interface.html
 
  ┏━┓┏┓┏┳━━┓
- ┃┏┓┫┃┃┃┃━┫  ${await getVersion()}
+ ┃┏┓┫┃┃┃┃━┫  ${version}
  ┃┃┃┃┗┛┃┃━┫  nuejs.org
  ┗┛┗┻━━┻━━┛
 `

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -4,7 +4,7 @@ import { sep } from 'node:path'
 
 import esMain from 'es-main'
 
-import { log, colors, getVersion, getEngine } from './util.js'
+import { log, colors, version, getEngine } from './util.js'
 
 
 // [-npe] --> [-n, -p, -e]
@@ -83,9 +83,7 @@ async function printHelp() {
 }
 
 async function printVersion() {
-  const v = await getVersion()
-  log(`Nue ${v} ${colors.green('•')} ${getEngine()}`)
-  return v
+  log(`Nue ${version} ${colors.green('•')} ${getEngine()}`)
 }
 
 async function runCommand(args) {
@@ -96,14 +94,14 @@ async function runCommand(args) {
   if (!root) args.root = '.' // ensure root is unset for create, if not set manually
 
   console.info('')
+  await printVersion()
+  args.nuekit_version = version
 
   // create nue
   if (cmd == 'create') {
     const { create } = await import('./create.js')
-    return await create({ root, name: args.paths[0], port })
+    return await create({ ...args, root, name: args.paths[0], port })
   }
-
-  args.nuekit_version = await printVersion()
 
   const nue = await createKit(args)
   if (!nue) return

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -4,7 +4,7 @@ import { sep } from 'node:path'
 
 import esMain from 'es-main'
 
-import { log, colors, version, getEngine } from './util.js'
+import { log, colors, version, getEngine, openUrl } from './util.js'
 
 
 // [-npe] --> [-n, -p, -e]
@@ -22,7 +22,7 @@ export function expandArgs(args) {
 
 // TODO: tests
 export function getArgs(argv) {
-  const commands = ['serve', 'build', 'init', 'create']
+  const commands = ['serve', 'build', 'init', 'create', 'docs']
   const args = { paths: [], root: null }
   const checkExecutable = /[\\\/]nue(\.(cmd|ps1|bunx|exe))?$/
   let opt
@@ -52,6 +52,7 @@ export function getArgs(argv) {
       else if (['-l', '--lcss'].includes(arg)) args.lcss = true
       else if (['-d', '--deploy'].includes(arg)) args.deploy = args.is_prod = true
       else if (['-I', '--incremental'].includes(arg)) args.incremental = true
+      else if (['-o', '--open'].includes(arg)) args.open = true
 
       // string values
       else if (['-e', '--environment'].includes(arg)) opt = 'env'
@@ -87,6 +88,8 @@ async function printVersion() {
 }
 
 async function runCommand(args) {
+  if (args.cmd == 'docs') return openUrl('https://nuejs.org/docs/')
+
   const { createKit } = await import('./nuekit.js')
   const { cmd = 'serve', dryrun, deploy, root = null, port } = args
   const init = cmd == 'init'
@@ -105,6 +108,7 @@ async function runCommand(args) {
 
   const nue = await createKit(args)
   if (!nue) return
+  if (args.open) openUrl(`http://localhost:${nue.port}/`)
 
   // deployer (private repo)
   const { deploy: deployer } = deploy ? await import('nue-deployer') : {}

--- a/packages/nuekit/src/init.js
+++ b/packages/nuekit/src/init.js
@@ -6,7 +6,7 @@ import { resolve } from 'import-meta-resolve'
 import { compileFile as nueCompile } from 'nuejs-core'
 
 import { buildJS } from './builder.js'
-import { colors, srcdir } from './util.js'
+import { version, colors, srcdir } from './util.js'
 
 
 export async function initNueDir({ dist, is_dev, esbuild, force }) {
@@ -15,7 +15,7 @@ export async function initNueDir({ dist, is_dev, esbuild, force }) {
   const outdir = join(cwd, dist, '@nue')
 
   // has all latest?
-  const latest = join(outdir, '.rc-2')
+  const latest = join(outdir, `.v${version}`)
 
   if (force || !existsSync(latest)) {
     await fs.rm(outdir, { recursive: true, force: true })

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -1,5 +1,6 @@
 /* misc stuff. think shame.css */
 
+import { execSync } from 'node:child_process'
 import { promises as fs } from 'node:fs'
 import { sep, parse, resolve, normalize, join, isAbsolute, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -7,14 +8,17 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 export const srcdir = dirname(fileURLToPath(import.meta.url))
 
-export const openUrl = process.platform == 'darwin' ? 'open' : process.platform == 'win32' ? 'start' : 'xdg-open'
+export function openUrl(url) {
+  const open = process.platform == 'darwin' ? 'open' : process.platform == 'win32' ? 'start' : 'xdg-open'
+  execSync(`${open} ${url}`)
+}
 
 // read from package.json
-export async function getVersion() {
+export const version = await async function() {
   const path = join(srcdir, '../package.json')
   const json = await fs.readFile(path, 'utf-8')
   return JSON.parse(json).version
-}
+}()
 
 export async function importFromCWD(path) {
   const abs_path = resolve(process.cwd(), path)


### PR DESCRIPTION
- set & show nue version before `create`
- simpler usage of `version` by running function on startup
- prepare `create` for more templates
- pass more args to `create` (e.g. usage of `nue create simple-blog -p` works now.)
- no more manual version file entries: `@nue/.v<current nuekit version>` file is now automatically created
- add `docs` command for quick access (can remove if unwanted)
- add `--open` option, to allow opening website on nue serve
- ...

If this gets accepted, #466 might need some changes