### PR TITLE
fix(glow): Lua/Haskell comment on its own line

### DIFF
--- a/packages/glow/src/glow.js
+++ b/packages/glow/src/glow.js
@@ -249,6 +249,7 @@ export function parseSyntax(lines, lang, prefix = true) {
         const c = line[0]
         let wrap = prefix && (is_md ? (c == '|' && 'dfn') : PREFIXES[c])
         if (wrap && is_md && line == '---') wrap = null
+        if (wrap && ['lua', 'haskell'].includes(lang) && line.startsWith('--')) wrap = null 
         if (wrap) line = (line[1] == ' ' ? ' ' : '') + line.slice(1)
 
         // escape character

--- a/packages/glow/test/glow.test.js
+++ b/packages/glow/test/glow.test.js
@@ -25,6 +25,11 @@ test('Emphasis', () => {
   expect(html).toInclude('</i></mark> girl')
 })
 
+test('parse Lua comment on its own line', () => {
+  const html = renderRow('-- comment', 'lua')
+  expect(html).toBe('<sup>-- comment</sup>')
+})
+
 
 /* multiline comments */
 test('parse HTML comment', () => {


### PR DESCRIPTION
For Lua/Haskell languages, avoid parse lines starting with `--` as deleted lines.