### PR TITLE
fix(nuemark): reflink followed by link

### DIFF
--- a/packages/nuemark/src/parse-inline.js
+++ b/packages/nuemark/src/parse-inline.js
@@ -186,8 +186,8 @@ export function parseLink(str, is_reflink) {
   // label
   let label = str.slice(1, i)
 
-  // image inside label
-  if (label.includes('![')) {
+  // image / reflink inside label
+  if (label.includes('![') || label.includes('][')) {
     i = str.indexOf(']' + open, j)
     label = str.slice(1, i)
     j = str.indexOf(close, i + 2)

--- a/packages/nuemark/test/inline.test.js
+++ b/packages/nuemark/test/inline.test.js
@@ -142,6 +142,28 @@ test('parse reflink', () => {
   expect(link).toMatchObject({ href: 'world', title: 'now', label: 'Hello' })
 })
 
+test('parse reflink + link', () => {
+  const tokens = parseInline('hello [ref][r] world [link](/)')
+  expect(tokens.length).toBe(4)
+  expect(tokens).toEqual([
+    { text: 'hello ' },
+    {
+      href: "r",
+      title: undefined,
+      label: "ref",
+      is_footnote: false,
+      is_reflink: true,
+    },
+    { text: ' world ' },
+    {
+      href: "/",
+      title: undefined,
+      label: "link",
+      is_footnote: false,
+      is_reflink: undefined,
+    },
+  ])
+})
 
 test('bad component names', () => {
   const tests = ['[(10)] [3 % 8]', '[-hey]', '[he+y] there']


### PR DESCRIPTION
See fail e.g. here: https://nuejs.org/blog/rethinking-reactivity/#keeping-things-small

> [!Note]
> parsed `[ref][r] ... [link](/)`:
> previously as: `<a href="/">ref]<r custom="r"></r> ... [link</a>`
> with this fix: `<a href="r">ref</a> ... <a href="/">link</a>`
