### PR TITLE
docs: "skip to content" button

### DIFF
--- a/packages/nuejs.org/@global/global.css
+++ b/packages/nuejs.org/@global/global.css
@@ -83,4 +83,18 @@ dl {
   }
 }
 
+/* skip to main content button */
+.skip {
+  position: absolute;
+  top: -100%;
+  left: -100%;
+  margin: 0.5em;
 
+  &:focus {
+    top: 0;
+    left: 0;
+  }
+}
+
+/* fix scrolling behind header */
+article, h1 { scroll-margin-top: 1.75em; }

--- a/packages/nuejs.org/@global/global.css
+++ b/packages/nuejs.org/@global/global.css
@@ -83,18 +83,5 @@ dl {
   }
 }
 
-/* skip to main content button */
-.skip {
-  position: absolute;
-  top: -100%;
-  left: -100%;
-  margin: 0.5em;
-
-  &:focus {
-    top: 0;
-    left: 0;
-  }
-}
-
 /* fix scrolling behind header */
 article, h1 { scroll-margin-top: 1.75em; }

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -1,6 +1,7 @@
 
 <!-- site header -->
 <header>
+  <a class="button skip" href="#main-content">Jump to main content</a>
   <navi :items="globalnav.main"/>
   <navi :items="globalnav.toolbar"/>
   <button class="action" popovertarget="menu">

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -1,7 +1,7 @@
 
 <!-- site header -->
 <header>
-  <a class="button skip" href="#main-content">Jump to main content</a>
+  <a class="button skip" href="#main-content">Skip to content</a>
   <navi :items="globalnav.main"/>
   <navi :items="globalnav.toolbar"/>
   <button class="action" popovertarget="menu">

--- a/packages/nuejs.org/@global/navigation.css
+++ b/packages/nuejs.org/@global/navigation.css
@@ -8,6 +8,19 @@ nav a {
 }
 
 
+/* skip to main content button */
+.skip {
+  position: absolute;
+  top: -100%;
+  left: -100%;
+  margin: 0.5em;
+
+  &:focus {
+    top: 0;
+    left: 0;
+  }
+}
+
 /* global header */
 body > header {
   margin-bottom: 5em;

--- a/packages/nuejs.org/@global/navigation.css
+++ b/packages/nuejs.org/@global/navigation.css
@@ -77,7 +77,7 @@ body > header {
   @media (width < 800px) {
     > * { display: none }
     button { display: inline-block }
-    nav:first-child {
+    nav:first-of-type {
       display: flex;
 
       @media (width < 650) {

--- a/packages/nuekit/src/layout/page.js
+++ b/packages/nuekit/src/layout/page.js
@@ -11,7 +11,7 @@ const MAIN = parseNue(`
   <main>
     <slot for="aside"/>
 
-    <article>
+    <article id="main-content">
       <slot for="pagehead"/>
       <slot for="content"/>
       <slot for="pagefoot"/>


### PR DESCRIPTION
On first <kbd>tab</kbd> you get a link to "jump to the main content":

before first tab:
![grafik](https://github.com/user-attachments/assets/a515c227-7f61-43a7-a1ff-11431bfc427b)
after first tab:
![grafik](https://github.com/user-attachments/assets/ee808408-4571-415d-982f-5787a0702b8f)

Prevents having to tab through all navigation elements (especially on the docs pages)

Best to just try it out locally.