### PR TITLE
chore: error notice when using plain js in component script

### DIFF
--- a/packages/nuejs/src/render.js
+++ b/packages/nuejs/src/render.js
@@ -304,7 +304,18 @@ function createComponent(node, global_js = '', template) {
 
   // javascript
   const js = getJS(node.children)
-  const Impl = js[0] && exec(`class Impl { ${js} }\n${global_js}`)
+  let Impl
+  try {
+    Impl = js[0] && exec(`class Impl { ${js} }\n${global_js}`)
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      throw [
+        e.toString(),
+        "Failed building component class, maybe you wanted to use '<script>' with a 'type' attribute?"
+      ].join('\n  ' + ''.padStart(e.name.length))
+    }
+    throw e
+  }
 
   // must be after getJS()
   const tmpl = getOuterHTML(node)


### PR DESCRIPTION
- close #516

```html
<footer>
  <script>
  console.log('hi')
  </script>
</footer>
```
![image](https://github.com/user-attachments/assets/62a4725d-cba8-49fe-ab5e-bd2779ddf05e)


> [!note]
> Hmmm. maybe that's a bit vague, because this can also always happen, if you have an error in the components's script.
> checking for `class field` in the error message also won't work, because Node doesn't add this information
> node: ![image](https://github.com/user-attachments/assets/3d371cca-7549-47d4-914f-ed3ca0a62d4c)

Please let me know, if you have better error messages in mind, that expand my message addition (last line), by mentioning that it could also be an error in their component's script.
