### PR TITLE
fix: Properly detect main module in symlink environments

### DIFF
--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -124,7 +124,7 @@ async function runCommand(args) {
 }
 
 // Only run main when called as real CLI
-if (esMain(import.meta)) {
+if (esMain(import.meta.url)) {
 
   const args = getArgs(process.argv.slice(2))
 

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -6,6 +6,7 @@ import { promises as fs } from 'node:fs'
 import { sep, parse, resolve, normalize, join, isAbsolute, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
+
 export const srcdir = dirname(fileURLToPath(import.meta.url))
 
 export function openUrl(url) {

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -1,10 +1,10 @@
 /* misc stuff. think shame.css */
 
 import { execSync } from 'node:child_process'
+import { realpathSync } from 'node:fs'
 import { promises as fs } from 'node:fs'
 import { sep, parse, resolve, normalize, join, isAbsolute, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-
 
 export const srcdir = dirname(fileURLToPath(import.meta.url))
 
@@ -14,8 +14,8 @@ export function openUrl(url) {
 }
 
 export function esMain(meta) {
-  if (!meta || !process.argv[1]) return false
-  return fileURLToPath(meta.resolve(process.argv[1])) === fileURLToPath(meta.url)
+  if (!meta || !process.argv[1]) return false;
+  return realpathSync(fileURLToPath(meta.url)) === realpathSync(process.argv[1]);
 }
 
 // read from package.json

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -14,8 +14,8 @@ export function openUrl(url) {
 }
 
 export function esMain(meta) {
-  if (!meta || !process.argv[1]) return false;
-  return realpathSync(fileURLToPath(meta.url)) === realpathSync(process.argv[1]);
+  if (!meta || !process.argv[1]) return false
+  return realpathSync(fileURLToPath(meta.url)) === realpathSync(process.argv[1])
 }
 
 // read from package.json

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -1,8 +1,7 @@
 /* misc stuff. think shame.css */
 
 import { execSync } from 'node:child_process'
-import { realpathSync } from 'node:fs'
-import { promises as fs } from 'node:fs'
+import { promises as fs, realpathSync } from 'node:fs'
 import { sep, parse, resolve, normalize, join, isAbsolute, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 

--- a/packages/nuekit/src/util.js
+++ b/packages/nuekit/src/util.js
@@ -13,9 +13,9 @@ export function openUrl(url) {
   execSync(`${open} ${url}`)
 }
 
-export function esMain(meta) {
-  if (!meta || !process.argv[1]) return false
-  return realpathSync(fileURLToPath(meta.url)) === realpathSync(process.argv[1])
+export function esMain(url) {
+  if (!url || !process.argv[1]) return false
+  return realpathSync(fileURLToPath(url)) === realpathSync(process.argv[1])
 }
 
 // read from package.json


### PR DESCRIPTION
On `Windows` and sometimes in other symlinked environments such as `pnpm` modules the `process.argv[1]` results in: `D:\Tool\pnpm\store\global\5\node_modules\nuekit\src\cli.js` which is an invalid path file URL:

```sh
meta.url: file:///D:/Tool/pnpm/store/global/5/.pnpm/nuekit@1.0.0-RC.3_esbuild@0_f01346d69ad6ce673c76ac54350ce1fe/node_modules/nuekit/src/cli.js
process.argv[1]: D:\Tool\pnpm\store\global\5\node_modules\nuekit\src\cli.js
```

```sh
Nikola in .../NikolaRHristov/Nue λ nue create simple-mpa
node:internal/url:1509
    throw new ERR_INVALID_URL_SCHEME('file');
          ^

TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file
    at fileURLToPath (node:internal/url:1509:11)
    at esMain (file:///D:/Tool/pnpm/store/global/5/.pnpm/nuekit@1.0.0-RC.3_esbuild@0_f01346d69ad6ce673c76ac54350ce1fe/node_modules/nuekit/src/util.js:18:10)
    at file:///D:/Tool/pnpm/store/global/5/.pnpm/nuekit@1.0.0-RC.3_esbuild@0_f01346d69ad6ce673c76ac54350ce1fe/node_modules/nuekit/src/cli.js:127:5 {
  code: 'ERR_INVALID_URL_SCHEME'
}
```

This PR changes the detection in `util.js` to use the `realpathSync` method which resolves to the original file path.

**Fix: Properly detect main module in symlink environments**

**Problem:**
The existing `esMain` check failed in pnpm environments due to symlinks, throwing "Invalid URL scheme" errors when comparing unresolved paths between the symlinked location and real module location.

**Cause:**
1. Used `meta.resolve()` unnecessarily with absolute paths
2. Compared raw paths instead of resolving symlinks
3. Failed to account for pnpm's content-addressable store structure

**Solution:**
- Remove error-prone `meta.resolve()` usage
- Use `realpathSync` to resolve canonical file paths
- Compare actual physical file locations instead of path strings

**Testing:**
Verified in pnpm environment where:
- `process.argv[1]` = symlink path (`node_modules/nuekit/src/cli.js`)
- `meta.url` = real path (`.pnpm-store/.../cli.js`)
- `realpathSync` resolves both to identical canonical paths

**Impact:**
More reliable main module detection in Node.js environments using symlink-based package managers like pnpm.