### PR TITLE
fix: nuekit create script call without args

### DIFF
--- a/packages/nuekit/src/create.js
+++ b/packages/nuekit/src/create.js
@@ -24,7 +24,7 @@ async function serve(args) {
 }
 
 export async function create(args = {}) {
-  if (!args.name) args.name = args.paths.shift().split('/').filter(Boolean).join('/') || 'simple-blog'
+  if (!args.name) args.name = args.paths.shift()?.split('/').filter(Boolean).join('/') || 'simple-blog'
   if (!args.root) args.root = args.paths.shift() || args.name.replaceAll('/', '-')
 
   // debug mode with: `nue create test`

--- a/packages/nuekit/src/create.js
+++ b/packages/nuekit/src/create.js
@@ -28,7 +28,7 @@ export async function create(args = {}) {
   if (!args.root) args.root = args.paths.shift() || args.name.replaceAll('/', '-')
 
   // debug mode with: `nue create test`
-  args.debug = args.name == 'test'
+  if (!args.debug) args.debug = args.name == 'test'
   if (args.debug) args.name = 'simple-blog'
 
   const { debug, name, root } = args

--- a/packages/nuekit/test/misc.test.js
+++ b/packages/nuekit/test/misc.test.js
@@ -99,3 +99,12 @@ test('create', async () => {
   expect(contents).toContain('index.md') // should be unpacked to correct dir
   expect(contents).toContain('.dist') // should be built
 }, 10_000)
+
+test('create without name arg', async () => {
+  const terminate = await create({ root, paths: [] })
+  terminate()
+
+  const contents = await fs.readdir(root)
+  expect(contents).toContain('index.md') // should use simple-blog template as the default
+  expect(contents).toContain('.dist') // should still be built
+}, 10_000)

--- a/packages/nuekit/test/misc.test.js
+++ b/packages/nuekit/test/misc.test.js
@@ -101,7 +101,7 @@ test('create', async () => {
 }, 10_000)
 
 test('create without name arg', async () => {
-  const terminate = await create({ root, paths: [] })
+  const terminate = await create({ root, paths: [], debug: true })
   terminate()
 
   const contents = await fs.readdir(root)


### PR DESCRIPTION
When calling `nue create` without any parameters, the current behavior is the following: 

```
nue create

✓ Nue 1.0.0-RC.3 • Bun 1.2.8
22 |   if (!args.debug) openUrl(`http://localhost:${nue.port}/${tmpl.open || ''}`)
23 |   return terminate
24 | }
25 |
26 | export async function create(args = {}) {
27 |   if (!args.name) args.name = args.paths.shift().split('/').filter(Boolean).join('/') || 'simple-blog'
                                                    ^
TypeError: undefined is not an object (evaluating 'args.paths.shift().split')
      at <anonymous> (/Users/lucas-prado-silva/.bun/install/global/node_modules/nuekit/src/create.js:27:48)
      at create (/Users/lucas-prado-silva/.bun/install/global/node_modules/nuekit/src/create.js:26:30)
      at <anonymous> (/Users/lucas-prado-silva/.bun/install/global/node_modules/nuekit/src/cli.js:101:18)
```

This PR makes sure that the `simple-blog` template is used as the default when no arguments are used, which seems to be what the previous code wanted to achieve.