### PR TITLE
feat(nuemark): modifiable code block component, docs: copy code button

### DIFF
--- a/packages/nuejs.org/@global/codeblock.css
+++ b/packages/nuejs.org/@global/codeblock.css
@@ -17,7 +17,7 @@
     border: var(--border);
 
     transition: opacity 250ms;
-    opacity: 0.25;
+    opacity: 0;
     &:is(:hover, :focus) { opacity: 1; }
 
     img {

--- a/packages/nuejs.org/@global/codeblock.css
+++ b/packages/nuejs.org/@global/codeblock.css
@@ -1,0 +1,26 @@
+.codeblock {
+  position: relative;
+
+  .copy {
+    font-size: 0.85rem;
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: inline-flex;
+    margin: 0.75rem;
+    padding: 0.25rem;
+
+    background: color-mix(in srgb, var(--gray-500), transparent);
+    backdrop-filter: blur(5px);
+    border: var(--border);
+
+    transition: opacity 250ms;
+    opacity: 0.5;
+    &:is(:hover, :focus) { opacity: 0.75; }
+
+    img {
+      filter: invert(1);
+      pointer-events: none;
+    }
+  }
+}

--- a/packages/nuejs.org/@global/codeblock.css
+++ b/packages/nuejs.org/@global/codeblock.css
@@ -1,6 +1,8 @@
 .codeblock {
   position: relative;
 
+  &:hover .copy { opacity: 0.5; }
+
   .copy {
     font-size: 0.85rem;
     position: absolute;
@@ -15,8 +17,8 @@
     border: var(--border);
 
     transition: opacity 250ms;
-    opacity: 0.5;
-    &:is(:hover, :focus) { opacity: 0.75; }
+    opacity: 0.25;
+    &:is(:hover, :focus) { opacity: 1; }
 
     img {
       filter: invert(1);

--- a/packages/nuejs.org/@global/global.js
+++ b/packages/nuejs.org/@global/global.js
@@ -1,19 +1,28 @@
 
 
-// hide popover menus
+
 addEventListener('click', event => {
   const el = event.target
+  
+  // hide popover menus
   const dialog = el.closest('[popover]')
-
   if (dialog) {
     const link = el.getAttribute('href')
     if (link) dialog.hidePopover()
   }
+  // copy to clipboard
   else if (el.dataset.copy) { // is copy button
     navigator.clipboard.writeText(decodeURIComponent(el.dataset.copy))
+    if (el.dataset.copied) return
+
+    el.dataset.copied = true
     const html = el.innerHTML
     el.innerText = 'Copied'
-    setTimeout(() => el.innerHTML = html, 1500)
+    
+    setTimeout(() => {
+      el.innerHTML = html
+      delete el.dataset.copied
+    }, 2000)
   }
 })
 

--- a/packages/nuejs.org/@global/global.js
+++ b/packages/nuejs.org/@global/global.js
@@ -9,6 +9,12 @@ addEventListener('click', event => {
     const link = el.getAttribute('href')
     if (link) dialog.hidePopover()
   }
+  else if (el.dataset.copy) { // is copy button
+    navigator.clipboard.writeText(decodeURIComponent(el.dataset.copy))
+    const html = el.innerHTML
+    el.innerText = 'Copied'
+    setTimeout(() => el.innerHTML = html, 1500)
+  }
 })
 
 

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -21,3 +21,12 @@
   </button>
   <navi :items="globalnav.menu"/>
 </dialog>
+
+<!-- copy button on code block -->
+<div @name="codeblock">
+  <button class="copy" :data-copy="encoded" onclick="navigator.clipboard.writeText(decodeURIComponent(event.target.dataset.copy))">copy</button>
+  <pre>{{html}}</pre>
+  <script>
+    constructor({ code }) { this.encoded = encodeURIComponent(code.join('\n')) }
+  </script>
+</div>

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -23,10 +23,12 @@
 </dialog>
 
 <!-- copy button on code block -->
-<pre @name="codeblock">
-<button class="copy" :data-copy="copy">Copy</button>
-<slot/>
-<script>
-  constructor({ code }) { this.copy = encodeURIComponent(code.join('\n')) }
-</script>
-</pre>
+<div @name="codeblock" class="codeblock">
+  <button class="copy" :data-copy="copy" title="Copy codeblock"><img src="/icon/copy.svg"></button>
+  <pre><slot/></pre>
+  <script>
+    constructor({ code }) {
+      this.copy = encodeURIComponent(code.join('\n'))
+    }
+  </script>
+</div>

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -24,7 +24,7 @@
 
 <!-- copy button on code block -->
 <div @name="codeblock" class="codeblock">
-  <button class="copy" :data-copy="copy" title="Copy codeblock"><img src="/icon/copy.svg"></button>
+  <button class="copy" :data-copy="copy" title="Copy code block"><img src="/icon/copy.svg"></button>
   <pre><slot/></pre>
   <script>
     constructor({ code }) {

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -23,10 +23,10 @@
 </dialog>
 
 <!-- copy button on code block -->
-<div @name="codeblock">
-  <button class="copy" :data-copy="encoded" onclick="navigator.clipboard.writeText(decodeURIComponent(event.target.dataset.copy))">copy</button>
-  <pre>{{html}}</pre>
-  <script>
-    constructor({ code }) { this.encoded = encodeURIComponent(code.join('\n')) }
-  </script>
-</div>
+<pre @name="codeblock">
+<button class="copy" :data-copy="copy">Copy</button>
+<slot/>
+<script>
+  constructor({ code }) { this.copy = encodeURIComponent(code.join('\n')) }
+</script>
+</pre>

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -23,7 +23,7 @@
 </dialog>
 
 <!-- copy button on code block -->
-<div @name="codeblock" class="codeblock">
+<div @name="codeblock" class="codeblock" :attr>
   <button class="copy" :data-copy="copy" title="Copy code block"><img src="/icon/copy.svg"></button>
   <pre><slot/></pre>
   <script>

--- a/packages/nuejs.org/@global/layout.html
+++ b/packages/nuejs.org/@global/layout.html
@@ -24,7 +24,7 @@
 
 <!-- copy button on code block -->
 <div @name="codeblock" class="codeblock" :attr>
-  <button class="copy" :data-copy="copy" title="Copy code block"><img src="/icon/copy.svg"></button>
+  <button class="copy" :data-copy="copy" title="Copy code block"><img src="/icon/copy.svg" alt=""></button>
   <pre><slot/></pre>
   <script>
     constructor({ code }) {

--- a/packages/nuejs.org/docs/core-components.md
+++ b/packages/nuejs.org/docs/core-components.md
@@ -229,3 +229,15 @@ The HTML output will resemble the following:
 The built-in `<page-list>` tag allows you to render a list of pages, such as blog entries or other index content, directly within your templates. This tag is ideal for creating dynamic lists that automatically update as you add new content to your site.
 
 To see how to collect and customize the pages in your list, refer to the [content collections](content-collections.html) documentation.
+
+## Code block
+
+The built-in `codeblock` component can be overwritten, to implement for example a copy code button.
+It has to be a layout component, and is by default defined as:
+
+```html
+<pre @name="codeblock" :attr><slot/></pre>
+```
+
+The component gets access to the data `language` and original `code` block code as list of lines.
+Attributes get passed through, and the `<slot>` is rendered as the highlighted code.

--- a/packages/nuejs.org/icon/copy.svg
+++ b/packages/nuejs.org/icon/copy.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+  stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+</svg>

--- a/packages/nuemark/src/render-blocks.js
+++ b/packages/nuemark/src/render-blocks.js
@@ -69,7 +69,7 @@ function renderCode({ name, code, attr, data }, opts) {
   delete attr.class
 
   let html = renderTag({
-      name: 'codeblock', attr, data: { code },
+      name: 'codeblock', attr, data: { ...data, language: name, code },
       blocks: [{ is_html: true, html: glow(code, { language: name, numbered }) }],
     }, opts)
 

--- a/packages/nuemark/src/render-blocks.js
+++ b/packages/nuemark/src/render-blocks.js
@@ -66,7 +66,13 @@ function renderCode({ name, code, attr, data }, opts) {
   const { numbered } = data
   const klass = attr.class
   delete attr.class
-  let html = elem('pre', attr, glow(code, { language: name, numbered }))
+  let html = renderTag(
+    {
+      name: 'codeblock', attr,
+      data: { code, html: glow(code, { language: name, numbered }) }
+    },
+    opts,
+  )
 
   const caption = data.caption || data._
 

--- a/packages/nuemark/src/render-blocks.js
+++ b/packages/nuemark/src/render-blocks.js
@@ -29,7 +29,8 @@ function renderBlock(block, opts) {
               block.is_code ? renderCode(block, opts) :
                 block.is_newline ? '' :
                   block.is_break ? '<hr>' :
-                    console.error('Unknown block', block)
+                    block.is_html ? block.html :
+                      console.error('Unknown block', block)
 }
 
 // recursive
@@ -66,13 +67,11 @@ function renderCode({ name, code, attr, data }, opts) {
   const { numbered } = data
   const klass = attr.class
   delete attr.class
-  let html = renderTag(
-    {
-      name: 'codeblock', attr,
-      data: { code, html: glow(code, { language: name, numbered }) }
-    },
-    opts,
-  )
+
+  let html = renderTag({
+      name: 'codeblock', attr, data: { code },
+      blocks: [{ is_html: true, html: glow(code, { language: name, numbered }) }],
+    }, opts)
 
   const caption = data.caption || data._
 

--- a/packages/nuemark/src/render-tag.js
+++ b/packages/nuemark/src/render-tag.js
@@ -10,6 +10,11 @@ import { join } from 'node:path'
 // built-in tags
 const TAGS = {
 
+  codeblock() {
+    const { attr, data } = this
+    return elem('pre', attr, data.html)
+  },
+
   accordion({ name, open }) {
     const html = this.sections?.map((blocks, i) => {
       const head = elem('summary', blocks[0].text)

--- a/packages/nuemark/src/render-tag.js
+++ b/packages/nuemark/src/render-tag.js
@@ -11,8 +11,8 @@ import { join } from 'node:path'
 const TAGS = {
 
   codeblock() {
-    const { attr, data } = this
-    return elem('pre', attr, data.html)
+    const { attr, blocks, render } = this
+    return elem('pre', attr, render(blocks))
   },
 
   accordion({ name, open }) {


### PR DESCRIPTION
- close #495 

Features:
- [x] redefinable code block component
  definition of the default layout codeblock component:
  ```html
  <pre @name="codeblock" :attr><slot/></pre>
  ```
- [x] code copy button
  |State|Img|
  |-|-|
  |Codeblock|![grafik](https://github.com/user-attachments/assets/649d5307-cd8f-42ac-9104-8407470b9243)|
  |Hovering Codeblock|  ![grafik](https://github.com/user-attachments/assets/3bfe8b49-c7cb-48cc-8b3a-5e19909a5cdc)|
  |Hovering Copy Button|  ![grafik](https://github.com/user-attachments/assets/fbc0da67-4ad4-4a83-b40f-17a9177d25e9)|
  |Clicked & Hovered Copy Button|  ![grafik](https://github.com/user-attachments/assets/02108873-c830-4353-a92a-85b66edc0c65)|
- [x] docs entry