### PR TITLE
feat: add node bin

### DIFF
--- a/packages/nuekit/package.json
+++ b/packages/nuekit/package.json
@@ -11,7 +11,8 @@
     "type": "git"
   },
   "bin": {
-    "nue": "./src/cli.js"
+    "nue": "./src/cli.js",
+    "nue-node": "./src/cli-node.js"
   },
   "engines": {
     "bun": ">= 1.2",

--- a/packages/nuekit/src/cli-node.js
+++ b/packages/nuekit/src/cli-node.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { run } from './cli.js'
+import { esMain } from './util.js'
+
+if (esMain(import.meta.url)) await run()

--- a/packages/nuekit/src/cli.js
+++ b/packages/nuekit/src/cli.js
@@ -123,9 +123,7 @@ async function runCommand(args) {
   }
 }
 
-// Only run main when called as real CLI
-if (esMain(import.meta.url)) {
-
+export async function run() {
   const args = getArgs(process.argv.slice(2))
 
   // help
@@ -145,3 +143,5 @@ if (esMain(import.meta.url)) {
     }
   }
 }
+
+if (esMain(import.meta.url)) await run()


### PR DESCRIPTION
Makes it way easier to run `nue` with `node` on Windows.
On Windows, there's no simple symlink to the `cli.js` file, but shell scripts, because windows doesn't support shebang AFAIK.
Therefore, you currently have to go into shell scripts (located at `where.exe nue`) and modify the executable from `bun` to `node`.
This is way harder than to simply installing `nuekit`, and deciding to use one of two commands, directly determining the JS runtime.

---

So available commands would be `nue` using `bun` and `nue-node` using `node`.
> [!Note] 
> We can also change the command `nue-node` to sth shorter, like `nnue` (for `node nue`)
