### PR TITLE
Update legacy introducing-hyper link

### DIFF
--- a/.github/workflows/repo/build-page/action.yaml
+++ b/.github/workflows/repo/build-page/action.yaml
@@ -1,9 +1,14 @@
 name: Repository nue page build
+description: |
+  Composite action to install dependencies, link nue, and build a Nue project.
 
 inputs:
   root:
+    description: |
+      The root directory of the Nue project to build.
+      This is passed to the `nue build` command.
     default: '.'
-    type: string
+    required: false
 
 runs:
   using: composite

--- a/.github/workflows/repo/build-page/action.yaml
+++ b/.github/workflows/repo/build-page/action.yaml
@@ -1,12 +1,12 @@
 name: Repository nue page build
 description: |
-  Composite action to install dependencies, link nue, and build a Nue project.
+  Internal composite action to install dependencies, register the `nue` command, and build a Nue project.
 
 inputs:
   root:
     description: |
       The root directory of the Nue project to build.
-      This is passed to the `nue build` command.
+      This is passed to the `--root` option of the `nue build` command.
     default: '.'
     required: false
 

--- a/packages/hyper/README.md
+++ b/packages/hyper/README.md
@@ -3,6 +3,6 @@
 # Hyper (Developer Preview)
 Hyper is a simple markup language for building user interfaces. It enables developers (and AI models) to generate complex UIs with amazingly clean syntax.
 
-[Launch post](https://nuejs.org/blog/introducing-hyper/) • [Docs](https://nuejs.org/hyper/)
+[Launch post](https://nuejs.org/blog/standards-first-react-alternative/) • [Docs](https://nuejs.org/hyper/)
 
-<img src="https://nuejs.org/blog/introducing-hyper/img/hyper-banner-dark-big.png" width="800">
+<img src="https://nuejs.org/blog/standards-first-react-alternative/img/hyper-banner-dark-big.png" width="800">

--- a/packages/hyper/package.json
+++ b/packages/hyper/package.json
@@ -2,7 +2,7 @@
   "name": "nue-hyper",
   "version": "0.1.1",
   "description": "Hyper is HTML markup for building user interfaces",
-  "homepage": "https://nuejs.org/blog/introducing-hyper/",
+  "homepage": "https://nuejs.org/blog/standards-first-react-alternative/",
   "main": "src/index.js",
   "license": "MIT",
   "type": "module",

--- a/packages/nuejs.org/blog/standards-first-react-alternative/complex-table.md
+++ b/packages/nuejs.org/blog/standards-first-react-alternative/complex-table.md
@@ -1,6 +1,6 @@
 
 ---
-back_to: introducing-hyper/
+back_to: standards-first-react-alternative/
 pagehead: false
 unlisted: true
 ---
@@ -353,9 +353,3 @@ Uses only about 40 lines of code, roughly 75% reduction in code to impolement th
   </script>
 </div>
 ```
-
-
-
-
-
-

--- a/packages/nuejs.org/blog/standards-first-react-alternative/simple-table.md
+++ b/packages/nuejs.org/blog/standards-first-react-alternative/simple-table.md
@@ -1,6 +1,6 @@
 
 ---
-back_to: introducing-hyper/
+back_to: standards-first-react-alternative/
 pagehead: false
 unlisted: true
 ---

--- a/packages/nuejs.org/hyper/index.md
+++ b/packages/nuejs.org/hyper/index.md
@@ -5,11 +5,11 @@ include: [technical-content]
 # Hyper documentation
 Hyper is a simple markup language for building user interfaces. Currently in **development preview**, it enables developers (and AI models) to generate complex UIs with a clean syntax.
 
-[Read the launch post](/blog/introducing-hyper/) for the backstory an FAQ
+[Read the launch post](/blog/standards-first-react-alternative/) for the backstory an FAQ
 
 [image.bordered]
-  large: /blog/introducing-hyper/img/hyper-banner-big.png
-  small: /blog/introducing-hyper/img/hyper-banner.png
+  large: /blog/standards-first-react-alternative/img/hyper-banner-big.png
+  small: /blog/standards-first-react-alternative/img/hyper-banner.png
   size: 598 × 237
 
 
@@ -59,7 +59,7 @@ The most significant change is the strict separation between components and CSS-
 
 For 3 and 4 Hyper currently issues a warning, but on the official releases there will be a configurable strict mode for production environments that throws an error.
 
-Read the [launch post](/blog/introducing-hyper/) for the complete rationale.
+Read the [launch post](/blog/standards-first-react-alternative/) for the complete rationale.
 
 
 
@@ -411,4 +411,3 @@ Pass arguments to CSS components without inline styling:
 <!-- renders as style="--gap: 3px" -->
 <div --gap="3px">...</div>
 ```
-


### PR DESCRIPTION
Updates the links to have the correct subdomain for the introducing hyper blog entry. From `introducing-hyper` to `standards-first-react-alternative`.

Also updates the `build-page/action.yaml` to align with github action syntax schema. See https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs.

This fixes the failing pipeline step, where all errors are 404 (`Network error: Not Found`) due to the broken subdomain:
```
## Errors per input

### Errors in http://localhost:8080/hyper/index.html

* [404] [http://localhost:8080/blog/introducing-hyper/img/hyper-banner.png](http://localhost:8080/blog/introducing-hyper/img/hyper-banner.png) | Network error: Not Found
* [404] [http://localhost:8080/blog/introducing-hyper/img/hyper-banner-big.png](http://localhost:8080/blog/introducing-hyper/img/hyper-banner-big.png) | Network error: Not Found
* [404] [http://localhost:8080/blog/introducing-hyper/](http://localhost:8080/blog/introducing-hyper/) | Network error: Not Found

### Errors in http://localhost:8080/blog/standards-first-react-alternative/complex-table.html

* [404] [http://localhost:8080/blog/introducing-hyper/](http://localhost:8080/blog/introducing-hyper/) | Error (cached)

### Errors in http://localhost:8080/blog/standards-first-react-alternative/simple-table.html

* [404] [http://localhost:8080/blog/introducing-hyper/](http://localhost:8080/blog/introducing-hyper/) | Error (cached)
```