### PR TITLE
Update html-syntax.md

### DIFF
--- a/packages/www/docs/html-syntax.md
+++ b/packages/www/docs/html-syntax.md
@@ -275,7 +275,9 @@ this.mount(name, target, data)
 ```
 
 **name** - Component name
+
 **target** - DOM element or CSS selector
+
 **data** - Optional data to pass to component
 
 ```html


### PR DESCRIPTION
These three lines run into one line when viewed in the browser. In theory a single carriage return should divide the line but it doesn't here. Two carried returns create a paragraph and it displays here correctly as separate lines.