### PR TITLE
fix: win create

### DIFF
--- a/packages/nuekit/src/cmd/create.js
+++ b/packages/nuekit/src/cmd/create.js
@@ -61,12 +61,13 @@ export async function unzip(dir, zip) {
     await Bun.write(filename, zip)
 
     // extract (expects "minimal" directory inside zip)
-    const proc = Bun.spawn(['unzip', '-q', filename])
+    const cmd = process.platform == 'win32' ? ['tar', '-xf', filename] : ['unzip', '-q', filename]
+    const proc = Bun.spawn(cmd)
     const exitCode = await proc.exited
 
     if (exitCode !== 0) {
       const stderr = await new Response(proc.stderr).text()
-      throw new Error(`unzip failed with exit code ${exitCode}: ${stderr}`)
+      throw new Error(`Unpacking archive failed with exit code ${exitCode}: ${stderr}`)
     }
 
   // clean up

--- a/packages/nuekit/test/cmd/create.test.js
+++ b/packages/nuekit/test/cmd/create.test.js
@@ -24,7 +24,7 @@ test('unzip', async () => {
   const zip = await getLocalZip(dir, 'cmd')
   await unzip(dir, zip)
   const files = await readdir(dir)
-  expect(files).toEqual([ "index.html", "index.css" ])
+  expect(new Set(files)).toEqual(new Set(["index.html", "index.css"]))
 })
 
 test('create', async () => {


### PR DESCRIPTION
fix #620.
Windows does not have `unzip`, but can unzip with `tar`.
(at least on my linux distro, `tar` can't unzip, though)