### PR TITLE
docs: fix unescaped highlight example

### DIFF
--- a/packages/www/docs/nuemark-syntax.md
+++ b/packages/www/docs/nuemark-syntax.md
@@ -71,7 +71,7 @@ Nuemark extends standard Markdown with additional formatting options:
 The bullet character `•` provides non-semantic bold:
 
 ```md
-•bold text•              → <b>bold text</b>
+\•bold text\•              → <b>bold text</b>
 ```
 
 

--- a/packages/www/docs/syntax-highlighting.md
+++ b/packages/www/docs/syntax-highlighting.md
@@ -83,7 +83,7 @@ Use bullet markers to highlight specific parts:
 ````md
  ```javascript
  const config = {
-   •name: "My App"•,
+   \•name: "My App"\•,
    version: "1.0.0"
  }
  ```
@@ -99,7 +99,7 @@ Double bullets mark errors:
 
 ````md
  ```javascript
- const data = ••undefned•• // typo
+ const data = \•\•undefned\•\• // typo
  ```
 ````
 


### PR DESCRIPTION
Future fix for docs code highlight examples.

> [!note]
> These fixes currently do not work, as the escaping is not used in glow.
