### PR TITLE
fix: importmap ordering

### DIFF
--- a/packages/nuekit/src/render/head.js
+++ b/packages/nuekit/src/render/head.js
@@ -34,8 +34,8 @@ export async function renderHead({ conf, data, assets, libs=[] }) {
   const scripts = renderScripts(assets)
 
   if (scripts.length || libs.length) {
-    head.push(...scripts)
     head.push(importMap(conf.import_map))
+    head.push(...scripts)
   }
 
   // RSS feed


### PR DESCRIPTION
fix #623 

modules were not being resolved properly on firefox, because some `script`s were already being loaded, when the `importmap` was found.
this is not allowed, at least in firefox, and caused components to not be loaded, as bare import specifiers etc. could not be resolved, because the importmap was ignored.