### PR TITLE
refactor: enhance unzip function for cross-platform support

### DIFF
--- a/packages/nuekit/test/cmd/create.test.js
+++ b/packages/nuekit/test/cmd/create.test.js
@@ -1,4 +1,3 @@
-
 import { create, unzip, getLocalZip, fetchZip } from '../../src/cmd/create'
 import { rm, readdir } from 'node:fs/promises'
 
@@ -23,8 +22,9 @@ test('unzip', async () => {
   const dir = 'minimal'
   const zip = await getLocalZip(dir, 'cmd')
   await unzip(dir, zip)
-  const files = await readdir(dir)
-  expect(files).toEqual([ "index.html", "index.css" ])
+  // read files inside minimal/minimal
+  const files = await readdir(`${dir}/${dir}`)
+  expect(files.sort()).toEqual(['index.css', 'index.html'])
 })
 
 test('create', async () => {


### PR DESCRIPTION
fix #622 

Improve the unzip function in create.js to use `tar` on Windows and `unzip` on Linux/macOS, ensure target directory creation, add numbered steps with comments for clarity, and implement proper cleanup of temporary ZIP files. Update tests to handle nested directory extraction and sort file lists for consistent comparison. These changes enable reliable template unzipping across platforms without external dependencies.